### PR TITLE
add user encode/decode

### DIFF
--- a/src/pvaproto.h
+++ b/src/pvaproto.h
@@ -102,7 +102,7 @@ class PVXS_API VectorOutBuf : public Buffer
 public:
     // note: vector::data() is not constexpr in c++11
     VectorOutBuf(bool be, std::vector<uint8_t>& b)
-        :base_type(be, b.data(), b.size())
+        :base_type(be, b.data()+b.size(), 0u)
         ,backing(b)
     {}
     virtual ~VectorOutBuf();

--- a/src/pvxs/data.h
+++ b/src/pvxs/data.h
@@ -805,6 +805,53 @@ std::ostream& operator<<(std::ostream& strm, const Value& val)
     return strm<<val.format();
 }
 
+//! Encoding and decoding Value as a byte array
+namespace xcode {
+
+/** Encode type definition to byte array
+ */
+PVXS_API
+void encodeType(std::vector<uint8_t>& buf, const Value& prototype, bool be=true);
+
+/** Encode full (for structures) Value to byte array.
+ *
+ * Provided Value must not be empty.
+ */
+PVXS_API
+void encodeFull(std::vector<uint8_t>& buf, const Value& value, bool be=true);
+
+/** Encode a bit-mask and only valid Value fields to byte array.
+ *
+ * Provided Value must be a Struct
+ */
+PVXS_API
+void encodeValid(std::vector<uint8_t>& buf, const Value& value, bool be=true);
+
+/** Decode type definition from byte array.
+ *
+ * Returns a prototype (empty) Value
+ */
+PVXS_API
+Value decodeType(const uint8_t*& buf, const uint8_t* bufend, bool be=true);
+
+/** Decode all fields and store in destination Value
+ *
+ * Caller must ensure that the destination Value matches
+ * the type definition used to encode field values.
+ */
+PVXS_API
+void decodeFull(Value &dest, const uint8_t*& buf, const uint8_t *bufend, bool be=true);
+
+/** Decode a bit-mask and only value fields and store in destination Value
+ *
+ * Caller must ensure that the destination Value matches
+ * the type definition used to encode field values.
+ */
+PVXS_API
+void decodeValid(Value& dest, const uint8_t*& buf, const uint8_t *bufend, bool be=true);
+
+} // namespace xcode
+
 } // namespace pvxs
 
 #endif // PVXS_DATA_H

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -461,6 +461,7 @@ void Server::Pvt::onSearch(const UDPManager::Search& msg)
     if(nreply==0 && !msg.mustReply)
         return;
 
+    searchReply.clear();
     VectorOutBuf M(true, searchReply);
 
     M.skip(8); // fill in header after body length known
@@ -495,6 +496,7 @@ void Server::Pvt::doBeacons(short evt)
 {
     log_debug_printf(serversetup, "Server beacon timer expires\n%s", "");
 
+    beaconMsg.clear();
     VectorOutBuf M(true, beaconMsg);
     M.skip(8); // fill in header after body length known
 

--- a/src/serverconn.cpp
+++ b/src/serverconn.cpp
@@ -42,7 +42,7 @@ ServerConn::ServerConn(ServIface* iface, evutil_socket_t sock, struct sockaddr *
 
     auto tx = bufferevent_get_output(bev.get());
 
-    std::vector<uint8_t> buf(128);
+    std::vector<uint8_t> buf;
 
     // queue connection validation message
     {

--- a/test/testudp.cpp
+++ b/test/testudp.cpp
@@ -113,7 +113,7 @@ void testSearch(bool be, std::initializer_list<const char*> names)
     });
     sub->start();
 
-    std::vector<uint8_t> msg(1024, 0);
+    std::vector<uint8_t> msg;
     VectorOutBuf M(be, msg);
 
     M.skip(8); // placeholder for header
@@ -132,7 +132,7 @@ void testSearch(bool be, std::initializer_list<const char*> names)
         to_wire(M, name);
     }
 
-    auto pktlen = M.save()-msg.data();
+    auto pktlen = M.consumed();
 
     FixedBuf H(be, msg.data(), 8);
     to_wire(H, Header{CMD_SEARCH, 0, uint32_t(pktlen-8)});


### PR DESCRIPTION
Attempt to address #9 with a user API for (de)serialization.  Three pairs of functions are added for the 3 contexts in which  PVD are found in the PVA protocol: Type, Full structure, and Partial structure.  The `xcode::encode*()` functions append to an `std::vector<uint8_t>`.  The `xcode::decode*()` functions operate on a pair of pointers (like iterators).  The first pointer is passed by reference, and updated based on the number of bytes consumed by each operation.