### PR TITLE
Create extra symlinks for old SONAMES?

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -45,3 +45,13 @@ CHECK_RELEASE = YES
 USR_CPPFLAGS_WIN32 += -DNOMINMAX -D_WIN32_WINNT=_WIN32_WINNT_VISTA
 
 USR_CPPFLAGS += -DUSE_TYPED_RSET
+
+# applied to all libraries
+SHRLIB_VERSION = $(PVXS_MAJOR_VERSION).$(PVXS_MINOR_VERSION).$(PVXS_MAINTENANCE_VERSION)
+
+# for ELF targets w/ shared libraries, emit additional symlinks
+ifeq (YES,$(SHARED_LIBRARIES))
+ifneq (,$(filter Linux,$(OS_CLASS)))
+COMPAT_VERSIONS = 0.1
+endif
+endif

--- a/configure/RULES
+++ b/configure/RULES
@@ -4,3 +4,21 @@ include $(CONFIG)/RULES
 
 # Library should be rebuilt because LIBOBJS may have changed.
 $(LIBNAME): ../Makefile
+
+# $1 is full qualified library name (libX.so.A.B)
+# $2 is compat suffix
+define COMPAT_def
+build: $$(INSTALL_SHRLIBS:%$$(SHRLIB_SUFFIX)=%$$(SHRLIB_SUFFIX_BASE).$2)
+# eg.
+#  ../../lib/linux-x86/libpvxs.so.0.0.0: Makefile
+#  	ln -s libpvxs.so.0.0.1 ../../lib/linux-x86/libpvxs.so.0.0.0
+$$(INSTALL_SHRLIBS:%$$(SHRLIB_SUFFIX)=%$$(SHRLIB_SUFFIX_BASE).$2): Makefile
+	$(RM) $$@
+	ln -s $$(notdir $$(@:%$$(SHRLIB_SUFFIX_BASE).$2=%$$(SHRLIB_SUFFIX))) $$@
+endef
+
+ifneq (,$(COMPAT_VERSIONS))
+$(foreach lib,$(INSTALL_SHRLIBS),\
+	$(foreach compat,$(COMPAT_VERSIONS),\
+		$(eval $(call COMPAT_def,$(lib),$(compat)))))
+endif

--- a/ioc/Makefile
+++ b/ioc/Makefile
@@ -19,8 +19,6 @@ INC += pvxs/iochooks.h
 
 LIBRARY += pvxsIoc
 
-SHRLIB_VERSION = $(PVXS_MAJOR_VERSION).$(PVXS_MINOR_VERSION)
-
 pvxsIoc_SRCS += iochooks.cpp
 
 LIB_LIBS += pvxs

--- a/src/Makefile
+++ b/src/Makefile
@@ -50,8 +50,6 @@ EXPANDFLAGS += $(foreach var,$(EXPANDVARS),-D$(var)="$(strip $($(var)))")
 GENVERSION = pvxsVCS.h
 GENVERSIONMACRO = PVXS_VCS_VERSION
 
-SHRLIB_VERSION = $(PVXS_MAJOR_VERSION).$(PVXS_MINOR_VERSION)
-
 INC += pvxs/version.h
 INC += pvxs/versionNum.h
 INC += pvxs/log.h


### PR DESCRIPTION
For ELF targets, currently only one qualified SONAME is installed `libpvxs.so.0.1`.  This doesn't capture the third (maintenance) version of a build.  So far I've been able to avoid removing/changing symbols, so code linked against older libpvxs can run against a newer release.  But I have added some, so this scheme doesn't fail well if the opposite happens, newer code against older libpvxs.

I've wondering if a better way to handle this is to include the full version in the SONAME, and also create additional symlinks for older compatible releases?

eg. if I had done this so far, then a future 0.1.4 release would install

```
$ ll lib/linux-x86_64/libpvxs.so*
... lib/linux-x86_64/libpvxs.so -> libpvxs.so.0.1.4
... lib/linux-x86_64/libpvxs.so.0.1.0 -> libpvxs.so.0.1.4
... lib/linux-x86_64/libpvxs.so.0.1.1 -> libpvxs.so.0.1.4
... lib/linux-x86_64/libpvxs.so.0.1.2 -> libpvxs.so.0.1.4
... lib/linux-x86_64/libpvxs.so.0.1.3 -> libpvxs.so.0.1.4
... lib/linux-x86_64/libpvxs.so.0.1.4
```

(I think in Mach-O land this would be expressed as `-current_version 0.1.4 -compatibility_version 0.1.0`)

This PR an attempt to add some RULES to do this.  eg. the preceding would be the result of:

```make
COMPAT_VERSIONS = 0.1.0 0.1.1 0.1.2 0.1.3
```

@anjohnson Any thoughts on the ideas or method?