### PR TITLE
Changed links to point to epics-base in documentation

### DIFF
--- a/documentation/building.rst
+++ b/documentation/building.rst
@@ -5,7 +5,7 @@ Building from Source
 
 Begin be fetching all needed source. ::
 
-    git clone --recursive https://github.com/mdavidsaver/pvxs.git
+    git clone --recursive https://github.com/epics-base/pvxs.git
     git clone --branch 7.0 https://github.com/epics-base/epics-base.git
 
 Prepare the PVXS source tree with the location of epics-base: ::

--- a/documentation/details.rst
+++ b/documentation/details.rst
@@ -7,12 +7,12 @@ Details
 Reporting a Bug
 ===============
 
-Before reporting a bug, please check to see if this issue has already been `reported <https://github.com/mdavidsaver/pvxs/issues>`_.
+Before reporting a bug, please check to see if this issue has already been `reported <https://github.com/epics-base/pvxs/issues>`_.
 
 When composing a new report, please run the included automatic tests "make runtests" and mention the results.
 It is enough to mention "All tests successful." if this is so.  (see `runtests`)
 
-`Bug reports <https://github.com/mdavidsaver/pvxs/issues>`_ should always include:
+`Bug reports <https://github.com/epics-base/pvxs/issues>`_ should always include:
 
 * EPICS Base version or VCS commit
 * PVXS module version or VCS commit
@@ -127,7 +127,7 @@ Elements of the Expert API may be "promoted" to regular/full API status if warra
 Contributing
 ============
 
-The recommended path for including changes is through `Pull Request <https://github.com/mdavidsaver/pvxs/pulls>`_.
+The recommended path for including changes is through `Pull Request <https://github.com/epics-base/pvxs/pulls>`_.
 
 When changing c++ code please do:
 
@@ -151,7 +151,7 @@ When committing changes please do:
 Contributors
 ------------
 
-Who did the [work](https://github.com/mdavidsaver/pvxs/graphs/contributors) to make PVXS what it is.
+Who did the [work](https://github.com/epics-base/pvxs/graphs/contributors) to make PVXS what it is.
 
 .. comment: git log --format=format:%aN|sort -u|while read aa; do echo "* $aa"; done
 

--- a/documentation/example.rst
+++ b/documentation/example.rst
@@ -4,7 +4,7 @@ Examples
 Example are built, but not installed.
 They can be found under example/O.\*
 
-Latest versions https://github.com/mdavidsaver/pvxs/blob/master/example/
+Latest versions https://github.com/epics-base/pvxs/blob/master/example/
 
 Shortest Client Get
 -------------------

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -9,9 +9,9 @@ PVXS is functionally equivalent to the
 `pvAccessCPP <https://github.com/epics-base/pvAccessCPP>`_ modules,
 which it hopes to eventually supplant (Ok, the author hopes).
 
-- VCS: https://github.com/mdavidsaver/pvxs
-- Docs: https://mdavidsaver.github.io/pvxs
-- `Issues <https://github.com/mdavidsaver/pvxs/issues>`_ (see :ref:`reportbug`)
+- VCS: https://github.com/epics-base/pvxs
+- Docs: https://epics-base.github.io/pvxs
+- `Issues <https://github.com/epics-base/pvxs/issues>`_ (see :ref:`reportbug`)
 - :ref:`contrib`
 
 Dependencies
@@ -31,7 +31,7 @@ See :ref:`building` for details.
 Download
 --------
 
-Releases are published to https://github.com/mdavidsaver/pvxs/releases.
+Releases are published to https://github.com/epics-base/pvxs/releases.
 See :ref:`relpolicy` for details.
 
 .. toctree::

--- a/documentation/pvalink-schema-0.json
+++ b/documentation/pvalink-schema-0.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://mdavidsaver.github.io/pvxs/pvalink-schema-0.json",
+    "$id": "https://epics-base.github.io/pvxs/pvalink-schema-0.json",
     "title": "PVA Link schema",
     "type": ["string", "object"],
     "properties": {

--- a/documentation/qsrv2-schema-0.json
+++ b/documentation/qsrv2-schema-0.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://mdavidsaver.github.io/pvxs/qsrv2-schema-0.json",
+    "$id": "https://epics-base.github.io/pvxs/qsrv2-schema-0.json",
     "title": "QSRV2 group schema",
     "type": "object",
     "additionalProperties": {


### PR DESCRIPTION
Replaced "mdavidsaver" in links with "epics-base" in documentation. Redirection works but maybe this is useful at some stage.