### PR TITLE
Add Python 3.12 Support

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -219,6 +219,11 @@ jobs:
       LIBEVENT_TAG: ${{ matrix.libevent }}
       EXTRA: ${{ matrix.extra }}
       VV: "1"
+      # The Node version was updated to Node20 in 'checkout', which breaks stuff
+      # This allows the use of the "unsecure" Node16
+      # THIS IS VERY MUCH A TEMPORARY FIX AND WILL STOP WORKING IN THE FUTURE
+      # https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     strategy:
       fail-fast: false
       matrix:
@@ -270,11 +275,6 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-      env:
-        # For some reason the Node version was updated to Node20, which breaks stuff
-        # This allows the use of the "insecure" Node20
-        # THIS IS VERY MUCH A TEMPORARY FIX
-        ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     - name: Automatic core dumper analysis
       uses: mdavidsaver/ci-core-dumper@master
       if: matrix.image!='centos:7'

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -240,7 +240,12 @@ jobs:
       # actions/checkout@v2 wants git >=2.18
       # centos:7 has 1.8
       if: matrix.image=='centos:7'
+      # By default, Centos 7 uses mirrorlist.centos.org for yum
+      # mirrorlist.centos.org no longer exists (as of 1st July 2024), so need to update repolist
       run: |
+        sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+        sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+        sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
         yum -y install curl make gcc curl-devel expat-devel gettext-devel openssl-devel zlib-devel perl-ExtUtils-MakeMaker
         curl https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.29.0.tar.gz | tar -xz
         cd git-*
@@ -265,6 +270,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
+      env:
+        # For some reason the Node version was updated to Node20, which breaks stuff
+        # This allows the use of the "insecure" Node20
+        # THIS IS VERY MUCH A TEMPORARY FIX
+        ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     - name: Automatic core dumper analysis
       uses: mdavidsaver/ci-core-dumper@master
       if: matrix.image!='centos:7'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -48,27 +48,27 @@ jobs:
           - name: osx 3.8 arm64
             os: macos-latest
             python: "3.8"
-            piparch: macosx_11_0_arm64
+            piparch: macosx_11_0_universal2
 
           - name: osx 3.9 arm64
             os: macos-latest
             python: "3.9"
-            piparch: macosx_11_0_arm64
+            piparch: macosx_11_0_universal2
 
           - name: osx 3.10 arm64
             os: macos-latest
             python: "3.10"
-            piparch: macosx_11_0_arm64
+            piparch: macosx_11_0_universal2
 
           - name: osx 3.11 arm64
             os: macos-latest
             python: "3.11"
-            piparch: macosx_11_0_arm64
+            piparch: macosx_11_0_universal2
 
           - name: osx 3.12 arm64
             os: macos-latest
             python: "3.12"
-            piparch: macosx_11_0_arm64
+            piparch: macosx_11_0_universal2
 
           # Windows py builds
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -36,34 +36,39 @@ jobs:
 
           # OSX py builds
           - name: osx 3.6 intel
-            os: macos-latest
+            os: macos-13
             python: "3.6"
             piparch: macosx_10_9_intel
 
           - name: osx 3.7 intel
-            os: macos-latest
+            os: macos-13
             python: "3.7"
             piparch: macosx_10_9_intel
 
-          - name: osx 3.8 intel
+          - name: osx 3.8 arm64
             os: macos-latest
             python: "3.8"
-            piparch: macosx_10_9_intel
+            piparch: macosx_11_0_arm64
 
-          - name: osx 3.9 intel
+          - name: osx 3.9 arm64
             os: macos-latest
             python: "3.9"
-            piparch: macosx_10_9_intel
+            piparch: macosx_11_0_arm64
 
-          - name: osx 3.10 intel
+          - name: osx 3.10 arm64
             os: macos-latest
             python: "3.10"
-            piparch: macosx_10_10_intel
+            piparch: macosx_11_0_arm64
 
-          - name: osx 3.11 intel
+          - name: osx 3.11 arm64
             os: macos-latest
             python: "3.11"
-            piparch: macosx_10_10_intel
+            piparch: macosx_11_0_arm64
+
+          - name: osx 3.12 arm64
+            os: macos-latest
+            python: "3.12"
+            piparch: macosx_11_0_arm64
 
           # Windows py builds
 
@@ -73,7 +78,7 @@ jobs:
           #  piparch: win_amd64
 
           - name: win64 3.5
-            os: windows-latest
+            os: windows-2019
             python: "3.5"
             piparch: win_amd64
 
@@ -107,6 +112,11 @@ jobs:
             python: "3.11"
             piparch: win_amd64
 
+          - name: win64 3.12
+            os: windows-latest
+            python: "3.12"
+            piparch: win_amd64
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -114,13 +124,18 @@ jobs:
       - name: Automatic core dumper analysis
         uses: mdavidsaver/ci-core-dumper@master
 
-
       - name: Setup native python
         if: matrix.python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           #architecture: x64
+
+      # TLS 1.0 and 1.1 support was removed from pypi so the cached pip won't work
+      - name: Python 3.5 Fix
+        if: ${{ matrix.python == '3.5' }}
+        run: |
+          curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | python
 
       - name: Prepare
         shell: bash
@@ -246,6 +261,12 @@ jobs:
             manylinux: manylinux2014
             arch: x86_64
 
+          - name: linux 3.12 amd64
+            os: ubuntu-latest
+            pyver: cp312-cp312
+            manylinux: manylinux2014
+            arch: x86_64
+
           # Linux py builds x32
           - name: linux 2.7 i686
             pyver: cp27-cp27m
@@ -301,7 +322,7 @@ jobs:
           submodules: recursive
 
       - name: Setup native python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python || '3.7' }}
           #architecture: x64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_dso>=2.11a2", "epicscorelibs>=7.0.7.99.1.0a2"]
+requires = ["setuptools", "wheel", "setuptools_dso>=2.7a1", "setuptools_dso>=2.11a2; python_version >= '3.12'", "epicscorelibs>=7.0.7.99.1.1a2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_dso>=2.7a1", "epicscorelibs>=7.0.3.99.2.0a1"]
+requires = ["setuptools", "wheel", "setuptools_dso>=2.11a2", "epicscorelibs>=7.0.7.99.1.0a2"]

--- a/setup.py
+++ b/setup.py
@@ -733,7 +733,7 @@ setup(
     #setup_requires = ['setuptools_dso'],
     # also need at runtime for DSO filename lookup
     install_requires = [
-        'setuptools_dso>=2.11a2',
+        'setuptools_dso>=2.7a1',
         epicscorelibs.version.abi_requires(),
     ],
     packages=['pvxslibs', 'pvxslibs.lib', 'pvxslibs.test'],

--- a/setup.py
+++ b/setup.py
@@ -733,7 +733,7 @@ setup(
     #setup_requires = ['setuptools_dso'],
     # also need at runtime for DSO filename lookup
     install_requires = [
-        'setuptools_dso>=2.7a1',
+        'setuptools_dso>=2.11a2',
         epicscorelibs.version.abi_requires(),
     ],
     packages=['pvxslibs', 'pvxslibs.lib', 'pvxslibs.test'],


### PR DESCRIPTION
Bumps versions of `setuptools_dso` and `epicscorelibs` to alpha releases with Python 3.12 support.