### PR TITLE
doc: client fix.

### DIFF
--- a/documentation/client.rst
+++ b/documentation/client.rst
@@ -21,7 +21,7 @@ EPICS_PVA_ADDR_LIST
     May contain unicast and/or broadcast addresses.
 
 EPICS_PVA_AUTO_ADDR_LIST
-    If "YES" then all local broadcast addresses will be implicitly appended to $EPICS_PVA_ADDR_LIST
+    If "YES" then all local broadcast addresses will be implicitly appended to $EPICS_PVA_ADDR_LIST.
     "YES" if unset.
 
 EPICS_PVA_NAME_SERVERS


### PR DESCRIPTION
Despite what the raw line wrapping makes it seem, there isn't a line break in the final generated documentation, so the text just goes directly from the environment variable name to its default value.