### PR TITLE
ioc: improve group processing warning messages.

### DIFF
--- a/ioc/groupconfigprocessor.cpp
+++ b/ioc/groupconfigprocessor.cpp
@@ -225,7 +225,7 @@ void GroupConfigProcessor::defineFields(GroupDefinition& groupDefinition, const 
         }
 
         if(fieldName.empty() && fieldConfig.info.type!=MappingInfo::Meta) {
-            fprintf(stderr, "%s.%s Error: only +type:\"meta\" map be mapped at struct top\n",
+            fprintf(stderr, "%s.%s Error: only +type:\"meta\" can be mapped at struct top\n",
                     groupName.c_str(), fieldName.c_str());
             continue;
         }

--- a/ioc/groupprocessorcontext.cpp
+++ b/ioc/groupprocessorcontext.cpp
@@ -33,8 +33,7 @@ void GroupProcessorContext::assign(const Value& value) {
             groupPvConfig.structureId = value.as<std::string>();
 
         } else {
-            groupConfigProcessor->groupProcessingWarnings += "Unknown group option ";
-            groupConfigProcessor->groupProcessingWarnings += field;
+            groupConfigProcessor->groupProcessingWarnings += SB()<<"Unknown group option: \""<<field<<"\"\n";
         }
         field.clear();
 
@@ -59,7 +58,7 @@ void GroupProcessorContext::assign(const Value& value) {
             } else if(tname == "const") {
                 type = MappingInfo::Const;
             } else {
-                groupConfigProcessor->groupProcessingWarnings += SB()<<"Unknown mapping +type:\""<<tname<<"\" ignored";
+                groupConfigProcessor->groupProcessingWarnings += SB()<<"Unknown mapping +type:\""<<tname<<"\" ignored\n";
             }
             groupField.info.type = type;
 
@@ -82,8 +81,7 @@ void GroupProcessorContext::assign(const Value& value) {
             groupField.info.cval = value;
 
         } else {
-            groupConfigProcessor->groupProcessingWarnings += "Unknown group field option ";
-            groupConfigProcessor->groupProcessingWarnings += field + ":" + key;
+            groupConfigProcessor->groupProcessingWarnings += SB()<<"Unknown group field option: \""<<field<<":"<<key<<"\"\n";
         }
         key.clear();
     }


### PR DESCRIPTION
Missing newlines and quotes made it hard to parse warning messages.