### PR TITLE
ioc: fix dbLoadGroups command.

### DIFF
--- a/ioc/groupsourcehooks.cpp
+++ b/ioc/groupsourcehooks.cpp
@@ -42,7 +42,6 @@ namespace ioc {
 static
 void dbLoadGroupCmd(const char* jsonFileName, const char *macros) {
     iocshSetError(!!dbLoadGroup(jsonFileName, macros));
-    GroupConfigProcessor().loadConfigFiles();
 }
 
 /**

--- a/test/qgroup.cmd
+++ b/test/qgroup.cmd
@@ -1,0 +1,1 @@
+dbLoadGroup("../qgroup.json", "N=tst:")

--- a/test/qgroup.json
+++ b/test/qgroup.json
@@ -1,0 +1,5 @@
+{
+    "$(N)fromFile": {
+        "value": {"+type": "const", "+const": 3}
+    }
+}


### PR DESCRIPTION
Calling GroupConfigProcessor().loadConfigFiles() reads and clears config.groupConfigFiles, and loads the JSON files before iocInit. When loadConfigFiles() is called again from an init-hook, config.groupConfigFiles is empty, and no JSON files are actually read, so no groups in those files are loaded.

This change removes error messages at the point where dbLoadGroup is called; errors are now displayed only during iocInit.

---

Fixes #88 

~~I would like to add tests before merging this.~~ Done!

I think I mostly understood what caused this problem, but I couldn't find where `config.groupMap` is cleared before/during `iocInit`, so I didn't understand why `loadConfigFiles()` before `iocInit` was an issue.

I'm assuming `groupConfigFiles` is cleared by `std::move` (this seems to be a [correct assumption](https://stackoverflow.com/questions/17730689/is-a-moved-from-vector-always-empty))~~, but if there's some spot that simply clears the whole `config`, it might simply be cleared along with `groupMap`.~~