### PR TITLE
client: defer notification of connect() failure

### DIFF
--- a/src/clientimpl.h
+++ b/src/clientimpl.h
@@ -86,6 +86,7 @@ struct Connection final : public ConnBase, public std::enable_shared_from_this<C
 
     // While HoldOff, the time until re-connection
     // While Connected, periodic Echo
+    // After early connect() failure, deferred notification
     const evevent echoTimer;
 
     bool ready = false;


### PR DESCRIPTION
Defer notification of connect() failure to bevEvent() callback to handle early failure the same as later disconnect.

Attempt to address #93
