### PR TITLE
ioc: fix DBE_ARCHIVE handling w/ singlesource

### DIFF
--- a/documentation/ioc.rst
+++ b/documentation/ioc.rst
@@ -128,6 +128,22 @@ Currently supported format hints are:
 - Exponential
 - Engineering
 
+When subscribing, the client provided ``pvRequest`` Value may contain the field
+``records._options.DBE`` with a string or unsigned integer.
+This value is mapped to a DataBase Event (DBE) bit mask.
+
+``DBE`` may be either a string or an unsigned integer.
+Use of an integer is recommended.
+The ``DBE_*`` macros from the ``caeventmask.h`` header may be used
+(``DBE_VALUE=1``, ``DBE_ARCHIVE=2``, ``DBE_ALARM=4``).
+``DBE_PROPERTY`` will be ignored if given as this event is always
+handled specially.
+Alternately, ``DBE`` may be a string using the old caProvider "parsing"
+rules.  This is not recommended.
+
+Until UNRELEASED ``DBE_ARCHIVE`` was not handled correctly.
+
+
 Group PV
 ^^^^^^^^
 

--- a/ioc/subscriptionctx.h
+++ b/ioc/subscriptionctx.h
@@ -25,6 +25,7 @@ namespace ioc {
 class Subscription {
     std::shared_ptr<std::remove_pointer<dbEventSubscription>::type> sub; // holds void* returned by db_add_event()
 public:
+    unsigned mask=0;
     /* Add a subscription event by calling db_add_event using the given subscriptionCtx
      * and selecting the correct elements based on the given type of event being added.
      * You need to specify the correct options that correspond to the event type.
@@ -45,6 +46,7 @@ public:
         });
         if(!sub)
             throw std::runtime_error("Failed to create db subscription");
+        mask = select;
     }
     void cancel() {
         sub.reset();

--- a/test/testpvreq.cpp
+++ b/test/testpvreq.cpp
@@ -390,11 +390,21 @@ void testArgs()
     );
 }
 
+void testDBE()
+{
+    testShow()<<__func__;
+
+    {
+        auto v(client::Context::request().pvRequest("record[DBE=VALUE]").build());
+        testEq(v["record._options.DBE"].as<std::string>(), "VALUE");
+    }
+}
+
 } // namespace
 
 MAIN(testpvreq)
 {
-    testPlan(38);
+    testPlan(39);
     testSetup();
     logger_config_env();
     testPvRequest();
@@ -409,6 +419,7 @@ MAIN(testpvreq)
     testError();
     testBuilder();
     testArgs();
+    testDBE();
     cleanup_for_valgrind();
     return testDone();
 }


### PR DESCRIPTION
Stop ignoring DBE_ARCHIVE (#97) for single PV.  Does not address group PV.

~~Add special 'record._options.DBE' to subscription Value to indicate actual mask used.~~  ...Dropped.