### PR TITLE
Sendto pktinfo

### DIFF
--- a/src/evhelper.h
+++ b/src/evhelper.h
@@ -316,8 +316,12 @@ struct PVXS_API IfaceMap {
     std::string name_of(const SockAddr& addr);
     // returns 0 if not found
     uint64_t index_of(const std::string& name);
+    // lookup interface index by interface address (not broadcast addr)
+    uint64_t index_of(const SockAddr& addr);
     // is this a valid interface or broadcast address?
     bool is_iface(const SockAddr& addr);
+    // is this index the/a loopback interface?
+    bool is_lo(uint64_t index);
     // is this a valid interface or broadcast address?
     bool is_broadcast(const SockAddr& addr);
     // look up interface address.  useful for IPV4.  returns AF_UNSPEC if not found

--- a/src/evhelper.h
+++ b/src/evhelper.h
@@ -302,55 +302,57 @@ struct PVXS_API evsocket
 
 struct PVXS_API IfaceMap {
     static
-    IfaceMap& instance();
+    IfaceMap instance();
     static
     void cleanup();
 
-    IfaceMap();
-
     // return true if ifindex is valid, and addr an interface address assigned to it.
-    bool has_address(uint64_t ifindex, const SockAddr& addr);
+    bool has_address(uint64_t ifindex, const SockAddr& addr) const;
     // lookup interface name by index
-    std::string name_of(uint64_t index);
+    std::string name_of(uint64_t index) const;
     // find (an) interface name with this address.  useful for IPv4.  returns empty string if not found.
-    std::string name_of(const SockAddr& addr);
+    std::string name_of(const SockAddr& addr) const;
     // returns 0 if not found
-    uint64_t index_of(const std::string& name);
+    uint64_t index_of(const std::string& name) const;
     // lookup interface index by interface address (not broadcast addr)
-    uint64_t index_of(const SockAddr& addr);
+    uint64_t index_of(const SockAddr& addr) const;
     // is this a valid interface or broadcast address?
-    bool is_iface(const SockAddr& addr);
+    bool is_iface(const SockAddr& addr) const;
     // is this index the/a loopback interface?
-    bool is_lo(uint64_t index);
+    bool is_lo(uint64_t index) const;
     // is this a valid interface or broadcast address?
-    bool is_broadcast(const SockAddr& addr);
+    bool is_broadcast(const SockAddr& addr) const;
     // look up interface address.  useful for IPV4.  returns AF_UNSPEC if not found
-    SockAddr address_of(const std::string& name);
+    SockAddr address_of(const std::string& name) const;
     // all interface names except LO
-    std::set<std::string> all_external();
-
-    // caller must hold lock
-    void refresh(bool force=false);
+    std::set<std::string> all_external() const;
 
     struct Iface {
         std::string name;
         uint64_t index;
         bool isLO;
-        // interface address(s) -> (maybe) broadcast addr
-        std::map<SockAddr, SockAddr, SockAddrOnlyLess> addrs;
+        // addrs - interface address -> (maybe) broadcast addr
+        // bcast - broadcast -> interface address
+        std::map<SockAddr, SockAddr, SockAddrOnlyLess> addrs, bcast;
         Iface(const std::string& name, uint64_t index, bool isLO) :name(name), index(index), isLO(isLO) {}
     };
 
-    SockAttach attach;
-    epicsMutex lock;
-    std::map<uint64_t, Iface> byIndex;
-    std::map<std::string, Iface*> byName;
-    // map address to tuple of interface and broadcast?
-    std::multimap<SockAddr, std::pair<Iface*, bool>, SockAddrOnlyLess> byAddr;
-    epicsTime updated;
+    struct Current {
+        std::map<uint64_t, Iface> byIndex;
+        std::map<std::string, Iface*> byName;
+        // map address to tuple of interface and broadcast?
+        std::multimap<SockAddr, std::pair<Iface*, bool>, SockAddrOnlyLess> byAddr;
+    };
+    std::shared_ptr<const Current> current;
+
+    IfaceMap() = default;
+    IfaceMap(const IfaceMap&) = default;
+    IfaceMap(std::shared_ptr<const Current>&& cur) : current(std::move(cur)) {}
+    static
+    std::shared_ptr<const Current> refresh();
 private:
     static
-    decltype (byIndex) _refresh();
+    decltype (Current::byIndex) _refresh();
 };
 
 } // namespace impl

--- a/src/os/WIN32/osdSockExt.cpp
+++ b/src/os/WIN32/osdSockExt.cpp
@@ -205,9 +205,9 @@ namespace impl {
 #  define GAA_FLAG_INCLUDE_ALL_INTERFACES 0
 #endif
 
-decltype (IfaceMap::byIndex) IfaceMap::_refresh() {
+decltype (IfaceMap::Current::byIndex) IfaceMap::_refresh() {
     std::vector<char> ifaces(1024u);
-    decltype (byIndex) temp;
+    decltype (Current::byIndex) temp;
 
     {
         constexpr ULONG flags = GAA_FLAG_SKIP_ANYCAST

--- a/src/os/default/osdSockExt.cpp
+++ b/src/os/default/osdSockExt.cpp
@@ -253,10 +253,10 @@ int sendtox::call()
 
 namespace impl {
 
-decltype (IfaceMap::byIndex) IfaceMap::_refresh() {
+decltype (IfaceMap::Current::byIndex) IfaceMap::_refresh() {
     ifaddrs* addrs = nullptr;
 
-    decltype (byIndex) temp;
+    decltype (Current::byIndex) temp;
 
     if(getifaddrs(&addrs)) {
         log_warn_printf(logiface, "Unable to getifaddrs() errno=%d\n", errno);

--- a/src/osiSockExt.h
+++ b/src/osiSockExt.h
@@ -214,6 +214,18 @@ struct recvfromx {
     int call();
 };
 
+struct sendtox {
+    evutil_socket_t sock;
+    const void *buf;
+    size_t buflen;
+    const SockAddr* dst;
+    const SockAddr* src; // if !NULL override UDP source address
+    uint64_t srcif;      // if !=0 override routing to send through this interface
+
+    PVXS_API
+    int call();
+};
+
 } // namespace pvxs
 
 #endif // OSISOCKEXT_H

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -441,14 +441,7 @@ Server::Pvt::Pvt(const Config &conf)
             listeners.push_back(manager.onSearch(any4, cb));
         }
 
-        if(evsocket::ipstack!=evsocket::Winsock
-                && addr.addr.family()==AF_INET && !addr.addr.isAny() && !addr.addr.isMCast()) {
-            /* An oddness of BSD sockets (not winsock) is that binding to
-             * INADDR_ANY will receive unicast and broadcast, but binding to
-             * a specific interface address receives only unicast.  The trick
-             * is to bind a second socket to the interface broadcast address,
-             * which will then receive only broadcasts.
-             */
+        if(addr.addr.family()==AF_INET && !addr.addr.isAny() && !addr.addr.isMCast()) {
             for(auto bcast : dummy.broadcasts(&addr.addr)) {
                 bcast.setPort(addr.addr.port());
                 listeners.push_back(manager.onSearch(bcast, cb));

--- a/src/udp_collector.cpp
+++ b/src/udp_collector.cpp
@@ -76,8 +76,8 @@ struct UDPCollector final : public UDPManager::Search,
             if(!(ev&EV_READ))
                 return;
 
-            // handle up to 4 packets before going back to the reactor
-            for(unsigned i=0; i<4 && self->handle_one(); i++) {}
+            // bound number of packets handled before going back to the reactor
+            for(unsigned i=0; i<16 && self->handle_one(); i++) {}
 
         }catch(std::exception& e) {
             log_crit_printf(logio, "Ignoring unhandled exception in UDPManager::handle(): %s\n", e.what());

--- a/src/udp_collector.cpp
+++ b/src/udp_collector.cpp
@@ -96,7 +96,7 @@ struct UDPManager::Pvt {
     SockAttach attach;
 
     evbase loop;
-    IfaceMap& ifmap;
+    IfaceMap ifmap;
 
     // only manipulate from loop worker thread
     // key'd by address family and port#

--- a/src/udp_collector.cpp
+++ b/src/udp_collector.cpp
@@ -58,33 +58,20 @@ struct UDPCollector final : public UDPManager::Search,
     void addListener(UDPListener *l);
     void delListener(UDPListener *l);
 
-    bool handle_one();
+    bool handle_one(const IfaceMap::Current &ifinfo);
 
     enum origin_t {
-        Remote,    // non-local sender
-        Local,     // sent from a local interface, including loopback
-        OriginTag, // payload of CMD_ORIGIN_TAG
+        Broadcast, // received directly from original client as bcast/mcast, process directly
+        Forwarding,// received directly from original client as ucast, forward
+        Forwarded, // forwarded by a local peer
+        OriginTag, // ... with CMD_ORIGIN_TAG
     };
 
-    void process_one(const SockAddr& dest, const uint8_t* buf, size_t nrx, origin_t origin);
-    static void handle_static(evutil_socket_t fd, short ev, void *raw)
-    {
-        (void)fd;
-        auto self = static_cast<UDPCollector*>(raw);
-        try {
-            log_debug_printf(logio, "UDP %p event %x\n", self->rx.get(), ev);
-            if(!(ev&EV_READ))
-                return;
+    void process_one(const uint8_t* buf, size_t nrx, origin_t origin,
+                     const IfaceMap::Current& ifinfo);
+    static void handle_static(evutil_socket_t fd, short ev, void *raw);
 
-            // bound number of packets handled before going back to the reactor
-            for(unsigned i=0; i<16 && self->handle_one(); i++) {}
-
-        }catch(std::exception& e) {
-            log_crit_printf(logio, "Ignoring unhandled exception in UDPManager::handle(): %s\n", e.what());
-        }
-    }
-
-    void forwardM(const SockAddr& origin, const uint8_t* buf, size_t len);
+    void forwardM(const uint8_t* buf, size_t len);
 
     // Search interface
 public:
@@ -221,13 +208,30 @@ void UDPCollector::delListener(UDPListener *l)
     // TODO: bother to cleanup mcast group membership?
 }
 
+void UDPCollector::handle_static(evutil_socket_t fd, short ev, void *raw)
+{
+    (void)fd;
+    auto self = static_cast<UDPCollector*>(raw);
+    try {
+        log_debug_printf(logio, "UDP %p event %x\n", self->rx.get(), ev);
+        if(!(ev&EV_READ))
+            return;
+
+        auto ifmap(self->manager->ifmap.current);
+
+        // bound number of packets handled before going back to the reactor
+        for(unsigned i=0; i<16 && self->handle_one(*ifmap); i++) {}
+
+    }catch(std::exception& e) {
+        log_crit_printf(logio, "Ignoring unhandled exception in UDPManager::handle(): %s\n", e.what());
+    }
+}
+
 // size of a CMD_ORIGIN_TAG prefix header
 static constexpr size_t cmd_origin_tag_size = 8 + 16;
 
-bool UDPCollector::handle_one()
+bool UDPCollector::handle_one(const IfaceMap::Current& ifinfo)
 {
-    SockAddr dest;
-
     buf.resize(cmd_origin_tag_size + 0x10000 + 1);
     auto rxbuf = &buf[cmd_origin_tag_size];
     auto rxlen = buf.size()-cmd_origin_tag_size-1;
@@ -249,7 +253,6 @@ bool UDPCollector::handle_one()
                             evutil_socket_error_to_string(err));
         }
         return false; // wait for more I/O
-
     }
 
     if(dest.family()!=AF_UNSPEC)
@@ -261,16 +264,65 @@ bool UDPCollector::handle_one()
         return true;
     }
 
-    log_hex_printf(logio, Level::Debug, rxbuf, nrx, "UDP Rx %d, %s -> %s @%u (%s)\n",
-            nrx, src.tostring().c_str(), dest.tostring().c_str(), unsigned(rx.dstif), bind_addr.tostring().c_str());
+    auto ifit(ifinfo.byIndex.find(rx.dstif));
+    if(ifit==ifinfo.byIndex.end()) {
+        log_debug_printf(logio, "Ignore UDP from as yet unknown iface index %u\n", unsigned(rx.dstif));
+        return true;
+    }
+    srcIface = &ifit->second;
 
-    origin_t origin = manager->ifmap.is_iface(src) ? Local : Remote;
+    // detect "origin" and reply-from address.  (dest in request becomes source in reply)
+    origin_t origin = Broadcast;
+    if(srcIface->isLO && dest.compare(lo_mcast_addr.addr,false)==0) {
+        // packet forwarded by a local PVA peer (maybe us) as IPv4 local multicast
+        origin = Forwarded;
+        // UDP header info of forwarder not relevant to reply.  Spoil...
+        src = dest = SockAddr(); // IPv6 does not support local mcast :(
+        srcIface = nullptr;
 
-    process_one(dest, rxbuf, nrx, origin);
+    } else {
+        // if destination is...
+        //   unicast (local iface addr), use as is
+        //   broadcast, look up corresponding local iface addr
+        //   multicast,
+        // ensure that dest is an interface address
+        auto ifit(srcIface->bcast.find(dest));
+        if(ifit!=srcIface->bcast.end()) {
+            // dest is bcast, so replace with associated iface address
+            dest = ifit->second;
+
+        } else if((ifit=srcIface->addrs.find(dest))!=srcIface->addrs.end()) {
+            // dest is interface address.  Nothing to do.
+            origin = Forwarding;
+
+        } else {
+            // mcast
+            // reply from an arbitrary address on the source interface
+            bool found = false;
+            for(auto& it : srcIface->addrs) {
+                if(it.first.family()==dest.family()) {
+                    dest = it.first;
+                    found = true;
+                    break;
+                }
+            }
+            if(!found) {
+                // let host mcast routing try...
+                dest = SockAddr(dest.family());
+            }
+        }
+    }
+
+    log_hex_printf(logio, Level::Debug, rxbuf, nrx, "UDP Rx %d, %s -> %s @%u (%s) : orig %d\n",
+                   nrx, src.tostring().c_str(), dest.tostring().c_str(), unsigned(rx.dstif), bind_addr.tostring().c_str(),
+                   origin);
+
+    process_one(rxbuf, nrx, origin, ifinfo);
     return true;
 }
 
-void UDPCollector::process_one(const SockAddr &dest, const uint8_t *buf, size_t nrx, origin_t origin)
+void UDPCollector::process_one(const uint8_t *buf, size_t nrx, origin_t origin,
+                               const IfaceMap::Current& ifinfo)
 {
     FixedBuf M(true, const_cast<uint8_t*>(buf), nrx);
     Header head{};
@@ -312,17 +364,20 @@ void UDPCollector::process_one(const SockAddr &dest, const uint8_t *buf, size_t 
         from_wire(M, port);
         if(server.isAny()) {
             server = src;
-            if(origin==OriginTag) {
-                log_err_printf(logio, "CMD_ORIGIN_TAG search with reply to sender never works%s", "\n");
+            if(origin==Forwarded || origin==OriginTag) {
+                log_warn_printf(logio, "Forwarded SEARCH with reply to sender never works.  Ignore.%s", "\n");
                 return;
             }
         }
         server.setPort(port);
 
-        if(!M.good() || !(flags&pva_search_flags::Unicast) || dest.family()!=AF_INET) {
-            // invalid, bcast, or not ipv4
+        if(!M.good())
+            return;
 
-        } else if(dest.compare(lo_mcast_addr.addr,false)!=0) {
+        if(origin==Broadcast || dest.family()!=AF_INET) {
+            // bcast, mcast, or not ipv4
+
+        } else if(origin==Forwarding) {
             assert(buf==&this->buf[cmd_origin_tag_size]);
             // clear unicast flag in forwarded message
             *save_flags &= ~pva_search_flags::Unicast;
@@ -332,7 +387,7 @@ void UDPCollector::process_one(const SockAddr &dest, const uint8_t *buf, size_t 
                 to_wire(R, server);
                 assert(R.good());
             }
-            forwardM(dest, buf, nrx);
+            forwardM(buf, nrx);
             return;
 
         } else {
@@ -436,20 +491,33 @@ void UDPCollector::process_one(const SockAddr &dest, const uint8_t *buf, size_t 
 
         // only allow one CMD_ORIGIN_TAG message per packet
         // only accept when sent to the mcast address through the loopback address
-        //   since we only join the mcast group on loopback this will hopefully
-        //   frustrate attempts to inject CMD_ORIGIN_TAG externally.
-        if(M.good() && origin==Local && dest.compare(lo_mcast_addr.addr,false)==0) {
-            originaddr.setPort(bind_addr.port());
-
-            process_one(originaddr, M.save(), M.size(), OriginTag);
-
+        // since we only join the mcast group on loopback this will hopefully
+        // frustrate attempts to inject CMD_ORIGIN_TAG externally.
+        if(!M.good()) {
+            log_err_printf(logio, "malformed ORIGIN_TAG from %s %c %d\n",
+                             originaddr.tostring().c_str(),
+                             M.good() ? 'T' : 'F',
+                             origin);
             return;
+
+        } else if(origin==Forwarded) {
+            auto ifit(ifinfo.byAddr.find(originaddr));
+            if(ifit!=ifinfo.byAddr.end()) {
+                // original destination is local interface address
+                originaddr.setPort(bind_addr.port());
+                dest = originaddr;
+                srcIface = ifit->second.first;
+                process_one(M.save(), M.size(), OriginTag, ifinfo);
+                return;
+
+            } else {
+                // forwarded w/ non-local ORIGIN_TAG??
+                log_warn_printf(logio, "Ignore originated from %s %d\n",
+                                 originaddr.tostring().c_str(),
+                                 origin);
+                // continue and try to process search as if directly received
+            }
         }
-        log_debug_printf(logio, "Ignore originated from %s %c%c%c\n",
-                         originaddr.tostring().c_str(),
-                         M.good() ? 'T' : 'F',
-                         origin==Local ? 'T' : 'F',
-                         dest.compare(lo_mcast_addr.addr,false)==0 ? 'T' : 'F');
 
         break;
     }
@@ -459,10 +527,10 @@ void UDPCollector::process_one(const SockAddr &dest, const uint8_t *buf, size_t 
     }
 }
 
-void UDPCollector::forwardM(const SockAddr& origin, const uint8_t *pbuf, size_t plen)
+void UDPCollector::forwardM(const uint8_t *pbuf, size_t plen)
 {
     log_debug_printf(logio, "Forward as originated for %s\n",
-                     origin.tostring().c_str());
+                     dest.tostring().c_str());
 
     assert(buf.size() > cmd_origin_tag_size);
     assert(pbuf==&buf[cmd_origin_tag_size]);
@@ -471,10 +539,14 @@ void UDPCollector::forwardM(const SockAddr& origin, const uint8_t *pbuf, size_t 
         FixedBuf M(true, &buf[0], cmd_origin_tag_size);
 
         to_wire(M, Header{CMD_ORIGIN_TAG, 0, 16u});
-        to_wire(M, origin);
+        to_wire(M, dest);
         assert(M.good());
         assert(M.save()==&buf[cmd_origin_tag_size]);
     }
+
+    // mcast_prep_sendto() will override routing
+    srcIface = nullptr;
+    dest = SockAddr(src.family());
 
     sock.mcast_prep_sendto(lo_mcast_addr);
     src = lo_mcast_addr.addr;
@@ -485,17 +557,21 @@ bool UDPCollector::reply(const void *msg, size_t msglen) const
 {
     manager->loop.assertInLoop();
 
-    log_hex_printf(logio, Level::Debug, msg, msglen, "Send %s -> %s\n",
-                   bind_addr.tostring().c_str(), src.tostring().c_str());
+    log_hex_printf(logio, Level::Debug, msg, msglen, "Send %s -> %s, %s,%s\n",
+                   bind_addr.tostring().c_str(), src.tostring().c_str(),
+                   dest.tostring().c_str(), srcIface ? srcIface->name.c_str() : "N/A");
 
-    auto ntx = sendto(sock.sock, (char*)msg, msglen, 0, &src->sa, src.size());
+    // reply to original source, through the original interface, as from original destination
+    auto ntx = sendtox{sock.sock, (char*)msg, msglen, &src, &dest, srcIface ? srcIface->index : 0}.call();
     if(ntx<0) {
         int err = evutil_socket_geterror(sock.sock);
         if(err==SOCK_EWOULDBLOCK || err==EAGAIN || err==SOCK_EINTR) {
             // nothing to do here
         } else {
-            log_warn_printf(logio, "UDP TX Error on %s -> %s : (%d) %s\n",
-                            name.c_str(), src.tostring().c_str(),
+            log_warn_printf(logio, "UDP TX Error: bound:%s src:%s,%s dst:%s : (%d) %s\n",
+                            name.c_str(),
+                            dest.tostring().c_str(), srcIface ? srcIface->name.c_str() : "N/A",
+                            src.tostring().c_str(),
                             err, evutil_socket_error_to_string(err));
         }
         return false; // wait for more I/O

--- a/src/udp_collector.h
+++ b/src/udp_collector.h
@@ -49,8 +49,10 @@ struct PVXS_API UDPManager
 
     struct PVXS_API Search {
         std::vector<std::string> otherproto; // any protocols other than "tcp"
-        SockAddr src;
+        SockAddr src; // sender/client address
+        SockAddr dest; // destination IP used by client
         SockAddr server;
+        const IfaceMap::Iface* srcIface = nullptr;
         uint32_t searchID;
         uint8_t peerVersion;
         bool protoTCP = false; // included protocol "tcp"

--- a/test/testsock.cpp
+++ b/test/testsock.cpp
@@ -180,18 +180,14 @@ void test_ifacemap()
 {
     testDiag("Enter %s", __func__);
 
-    auto& ifs = IfaceMap::instance();
+    auto ifs(IfaceMap::instance());
 
-    epicsGuard<epicsMutex> G(ifs.lock); // since we are playing around with the internals...
-
-    ifs.refresh(true);
-
-    testFalse(ifs.byIndex.empty())<<" found "<<ifs.byIndex.size()<<" interfaces";
+    testFalse(ifs.current->byIndex.empty())<<" found "<<ifs.current->byIndex.size()<<" interfaces";
 
     bool foundlo = false;
     const auto lo(SockAddr::loopback(AF_INET));
 
-    for(const auto& pair : ifs.byIndex) {
+    for(const auto& pair : ifs.current->byIndex) {
         auto& iface = pair.second;
         testDiag("Interface %u \"%s\"", unsigned(iface.index), iface.name.c_str());
         for(const auto& pair : iface.addrs) {
@@ -297,7 +293,7 @@ void test_local_mcast()
 {
     testDiag("Enter %s", __func__);
 
-    IfaceMap ifinfo;
+    auto ifinfo(IfaceMap::instance());
 
     evsocket A(AF_INET, SOCK_DGRAM, 0, true),
              B(AF_INET, SOCK_DGRAM, 0, true);

--- a/test/testsock.cpp
+++ b/test/testsock.cpp
@@ -220,6 +220,7 @@ void test_udp(int af)
     }
 
     A.enable_IP_PKTINFO();
+    B.enable_IP_PKTINFO();
     try{
         A.bind(bind_addr);
     }catch(std::system_error& e){
@@ -237,24 +238,59 @@ void test_udp(int af)
     testNotEq(send_addr.port(), 0);
     testNotEq(send_addr.port(), bind_addr.port());
 
-    uint8_t msg[] = {0x12, 0x34, 0x56, 0x78};
-    int ret = sendto(B.sock, (char*)msg, sizeof(msg), 0, &bind_addr->sa, bind_addr.size());
-    testOk(ret==(int)sizeof(msg), "Send test ret==%d(%d)", ret, EVUTIL_SOCKET_ERROR());
+    {
+        uint8_t msg[] = {0x12, 0x34, 0x56, 0x78};
+        int ret = sendtox{B.sock, (char*)msg, sizeof(msg), &bind_addr}.call();
+        testOk(ret==(int)sizeof(msg), "Send test ret==%d(%d)", ret, EVUTIL_SOCKET_ERROR());
+    }
 
-    uint8_t rxbuf[8] = {};
-    SockAddr src;
-    SockAddr dest;
+    SockAddr reply_to, reply_from;
+    uint64_t reply_from_iface = 0;
+    {
+        testDiag("Call recvfrom()");
 
-    testDiag("Call recvfrom()");
-    ret = recvfromx{A.sock, (char*)rxbuf, sizeof(rxbuf), &src, &dest}.call();
-    // only the destination address is captured, not the port
-    if(dest.family()!=AF_UNSPEC)
-        dest.setPort(bind_addr.port());
+        uint8_t rxbuf[8] = {};
+        SockAddr src, dest;
+        auto rx(recvfromx{A.sock, (char*)rxbuf, sizeof(rxbuf), &src, &dest});
+        int ret = rx.call();
+        // only the destination address is captured, not the port
+        if(dest.family()!=AF_UNSPEC)
+            dest.setPort(bind_addr.port());
 
-    testOk(ret==4 && rxbuf[0]==0x12 && rxbuf[1]==0x34 && rxbuf[2]==0x56 && rxbuf[3]==0x78,
-            "Recv'd %d(%d) [%u, %u, %u, %u]", ret, EVUTIL_SOCKET_ERROR(), rxbuf[0], rxbuf[1], rxbuf[2], rxbuf[3]);
-    testEq(src, send_addr);
-    testEq(dest, bind_addr);
+        testOk(ret==4 && rxbuf[0]==0x12 && rxbuf[1]==0x34 && rxbuf[2]==0x56 && rxbuf[3]==0x78,
+                "Recv'd %d(%d) [%u, %u, %u, %u]", ret, EVUTIL_SOCKET_ERROR(), rxbuf[0], rxbuf[1], rxbuf[2], rxbuf[3]);
+        testEq(src, send_addr);
+        testEq(dest, bind_addr);
+
+        reply_to = src;
+        reply_from = dest;
+        reply_from_iface = rx.dstif;
+    }
+
+    {
+        testDiag("Call sendto() with source addr override");
+        uint8_t msg[] = {0x9a, 0xbc, 0xde, 0xf0};
+        // reply to "src" from "dest"
+        int ret = sendtox{A.sock, (char*)msg, sizeof(msg), &reply_to, &reply_from, reply_from_iface}.call();
+        testOk(ret==(int)sizeof(msg), "Send test ret==%d(%d)", ret, EVUTIL_SOCKET_ERROR());
+    }
+
+    {
+        testDiag("Call recvfrom()");
+
+        uint8_t rxbuf[8] = {};
+        SockAddr src, dest;
+        auto rx(recvfromx{B.sock, (char*)rxbuf, sizeof(rxbuf), &src, &dest});
+        int ret = rx.call();
+        // only the destination address is captured, not the port
+        if(dest.family()!=AF_UNSPEC)
+            dest.setPort(send_addr.port());
+
+        testOk(ret==4 && rxbuf[0]==0x9a && rxbuf[1]==0xbc && rxbuf[2]==0xde && rxbuf[3]==0xf0,
+                "Recv'd %d(%d) [%u, %u, %u, %u]", ret, EVUTIL_SOCKET_ERROR(), rxbuf[0], rxbuf[1], rxbuf[2], rxbuf[3]);
+        testEq(src, reply_from);
+        testEq(dest, reply_to);
+    }
 }
 
 void test_local_mcast()
@@ -510,7 +546,7 @@ MAIN(testsock)
 {
     SockAttach attach;
     logger_config_env();
-    testPlan(93);
+    testPlan(101);
     testSetup();
     testStackID();
     testEndPoint();

--- a/test/testudpfwd.cpp
+++ b/test/testudpfwd.cpp
@@ -101,11 +101,9 @@ void testFwdIface()
 
     std::vector<SockAddr> ifaddrs;
     {
-        auto& ifs(IfaceMap::instance());
+        auto ifs(IfaceMap::instance());
 
-        epicsGuard<epicsMutex> G(ifs.lock);
-
-        for(auto it : ifs.byIndex) {
+        for(auto it : ifs.current->byIndex) {
             auto& iface = it.second;
             if(iface.isLO)
                 continue;

--- a/tools/mshim.cpp
+++ b/tools/mshim.cpp
@@ -76,7 +76,7 @@ SockEndpoint parseEP(const char* optarg, const server::Config& conf)
 
 struct App {
     const SockAttach attach;
-    IfaceMap& ifmap;
+    IfaceMap ifmap;
     const evsocket sockTx{AF_INET, SOCK_DGRAM, 0};
     std::vector<SockEndpoint> destinations;
 


### PR DESCRIPTION
Attempts to address this situation encountered with p4p.gw https://github.com/epics-base/p4p/issues/162 where a PVA client host is intentionally reachable by routes from multiple interfaces of a gateway host.  Because PVXS binds UDP sockets to `0.0.0.0` and `[::]`, a SEARCH reply will currently be sent by the most direct route, which may not be the one by which the original SEARCH request arrived.

This PR changes from `sendto()` to `sendmsg()` with a `IP_PKTINFO` or `IPV6_PKTINFO` control message specifying the requested outbound interface and/or source address.

The source address for a message forwarded by local multicast is taken from the `ORIGIN_TAG` message, when available and when an interface address.  An interface index is looked up from this.

Currently neither override is specified for non-unicast SEARCH replies, nor for BEACON.

This PR also changes the criteria for identifying a UDP message which has been forwarded by a local peer, even when a ORIGIN_TAG is not present.  This is done by looking at OS provided interface and destination address, which I think can be trusted.  This should also make it possible to distinguish traffic arriving over the loopback which has not be forwarded.

wrt. portability.  All major IP stacks I looked at (BSD, Linux, Windows) provide `IPV6_PKTINFO`.  `IP_PKTINFO` is provided by Linux and Windows, but not BSD.  So for RTEMS or OSX, a call to `sendmsg()` will be equivalent to `sendto()`.

@kasemir @FreddieAkeroyd  fyi.