### PR TITLE
Process requests targetting broadcast address

### DIFF
--- a/src/udp_collector.cpp
+++ b/src/udp_collector.cpp
@@ -390,6 +390,14 @@ void UDPCollector::process_one(const SockAddr &dest, const uint8_t *buf, size_t 
             for(auto L : listeners) {
                 if(L->searchCB && (L->dest.addr.isAny() || L->dest.addr==dest)) {
                     (L->searchCB)(*this);
+                } else if(L->searchCB && !(L->dest.addr.isAny())) {
+                    for(auto B : sock.broadcasts(&(L->dest.addr))) {
+                        if(!(B.compare(dest, false)) && (L->dest.addr.port() == dest.port())) {
+                            log_debug_printf(logio, "Processing broadcast %s on %s\n",
+                                dest.tostring().c_str(), L->dest.addr.tostring().c_str());
+                            (L->searchCB)(*this);
+                        }
+                    }                   
                 }
             }
 


### PR DESCRIPTION
I was running the following setup:

machine A - EPICS_PVA_ADDR_LIST=subnet_broadcast_address
machine B - p4p gateway on main network, IOCs bound to 127.0.0.1, p4p using 127.255.255.255 as EPICS_PVA_ADDR_LIST

I was unable to resolve IOC PVs on machine B from machine A until I made the enclosed changes
