### PR TITLE
Changed Float32/Float64 to Float32A/Float64A in the NTNDArray TypeDef

### DIFF
--- a/src/nt.cpp
+++ b/src/nt.cpp
@@ -215,8 +215,8 @@ TypeDef NTNDArray::build() const
                         UInt16A("ushortValue"),
                         UInt32A("uintValue"),
                         UInt64A("ulongValue"),
-                        Float32("floatValue"),
-                        Float64("doubleValue"),
+                        Float32A("floatValue"),
+                        Float64A("doubleValue"),
                     }),
                     Struct("codec", "codec_t", {
                         String("name"),


### PR DESCRIPTION
The union type of the `value` field in the `NTNDArray` definition is set to array types for all but `Float32` and `Float64`. 
Shouldn't they be also array types? 

I'm preparing some unit tests, but `make runtests` passed (for my Ubuntu machine).