### PR TITLE
Fixed pvaGetValue for Union types; Added tests

### DIFF
--- a/ioc/pvalink_lset.cpp
+++ b/ioc/pvalink_lset.cpp
@@ -252,7 +252,7 @@ long pvaGetValue(DBLINK *plink, short dbrType, void *pbuffer, long *pnRequest) n
         auto nReq(pnRequest ? *pnRequest : 1);
         auto value(self->fld_value);
 
-        if(value.type()==TypeCode::Any)
+        if(value.type()==TypeCode::Any || value.type()==TypeCode::Union)
             value = value.lookup("->");
 
         if(nReq <= 0 || !value) {

--- a/test/testnt.cpp
+++ b/test/testnt.cpp
@@ -53,6 +53,12 @@ void testNTNDArray()
     auto top = nt::NTNDArray{}.create();
 
     testTrue(top.idStartsWith("epics:nt/NTNDArray:"))<<"\n"<<top;
+
+    top["value->floatValue"] = shared_array<const float>({0.1, 0.2, 0.3, 0.4, 0.5});
+    testEq(top["value"].type(), TypeCode::Union);
+    top = top["value"].lookup("->");
+    testEq(top.type(), TypeCode::Float32A);
+
 }
 
 void testNTURI()
@@ -108,7 +114,7 @@ void testNTTable()
 } // namespace
 
 MAIN(testnt) {
-    testPlan(22);
+    testPlan(24);
     testNTScalar();
     testNTNDArray();
     testNTURI();

--- a/test/testpvalink.db
+++ b/test/testpvalink.db
@@ -204,3 +204,9 @@ record(waveform, "sarr:inp") {
     field(FTVL, "STRING")
     field(NELM, "16")
 }
+
+record(aai, "target:ntndarray_inp") {
+    field(INP,  {pva:{pv:"source:ntndarray", proc:"CP"}}) # created programatically with pvxs::server::SharedPV
+    field(NELM, "5")
+    field(FTVL, "FLOAT")
+}


### PR DESCRIPTION
The modification suggested in  #107 resolved the issue. I added some test cases to perform some basic checks in NTNDArrays entities. 