### PR TITLE
allow to  have pvxs in arbitrary location

### DIFF
--- a/configure/CONFIG_PVXS_MODULE
+++ b/configure/CONFIG_PVXS_MODULE
@@ -1,7 +1,3 @@
-# auto-compute location of this file.
-# avoid need to standardize configure/RELEASE name
-_PVXS := $(dir $(lastword $(MAKEFILE_LIST)))
-
 # we're appending so must be idempotent
 ifeq (,$(_PVXS_CONF_INCLUDED))
 _PVXS_CONF_INCLUDED := YES
@@ -16,7 +12,7 @@ ifdef T_A
 LIBEVENT ?= $(LIBEVENT_$(T_A))
 
 # default to bundled location if it exists
-LIBEVENT_$(T_A) ?= $(wildcard $(abspath $(_PVXS)/../bundle/usr/$(T_A)))
+LIBEVENT_$(T_A) ?= $(wildcard $(INSTALL_LOCATION)/bundle/usr/$(T_A))
 
 # apply to include search paths
 INCLUDES += $(if $(LIBEVENT),-I$(LIBEVENT)/include)


### PR DESCRIPTION
`bundle/usr` gets installed into `$(INSTALL_LOCATION)` but was searched for relative to the PVXS source directory, which only works under specific circumstances.