### PR TITLE
LIBEVENT hint for homebrew

### DIFF
--- a/documentation/building.rst
+++ b/documentation/building.rst
@@ -35,7 +35,7 @@ On Debian/Ubuntu. ::
 On macOS / Homebrew. ::
 
     brew install libevent
-    export LIBEVENT=/opt/homebrew
+    export LIBEVENT=$(brew --prefix)
 
 To build from source (Requires `CMake <https://cmake.org/>`_): ::
 

--- a/documentation/building.rst
+++ b/documentation/building.rst
@@ -32,6 +32,11 @@ On Debian/Ubuntu. ::
 
     apt-get install libevent-dev
 
+On macOS / Homebrew. ::
+
+    brew install libevent
+    export LIBEVENT=/opt/homebrew
+
 To build from source (Requires `CMake <https://cmake.org/>`_): ::
 
     make -C pvxs/bundle libevent # implies .$(EPICS_HOST_ARCH)


### PR DESCRIPTION
For macOS / homebrew install of `libevent` give the reader a hint on how to build, now updated to recognise that the brew installation prefix is configurable.