### PR TITLE
UDP search traverse NAT

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1074,8 +1074,12 @@ void ContextImpl::tickSearch(SearchKind kind, bool poked)
         // flags and reserved.
         // initially flags[7] is cleared (bcast)
         auto pflags = M.save();
-        to_wire(M, uint8_t(kind == SearchKind::discover ?
-                           pva_search_flags::MustReply : 0u)); // must-reply to discovery, ignore regular negative search
+        to_wire(M, uint8_t(
+                // must-reply to discovery, ignore regular negative search
+                (kind == SearchKind::discover ? pva_search_flags::MustReply : 0u)
+                | pva_search_flags::ReplySrcPort
+                )
+        );
         to_wire(M, uint8_t(0u));
         to_wire(M, uint16_t(0u));
 

--- a/src/pvaproto.h
+++ b/src/pvaproto.h
@@ -582,8 +582,8 @@ void from_wire(Buffer& buf, shared_array<const void>& varr)
 
 struct pva_version {
     enum {
-        client = 2,
-        server = 2,
+        client = 3,
+        server = 3,
     };
 };
 
@@ -643,6 +643,7 @@ enum pva_app_msg_t : uint8_t {
 struct pva_search_flags {
     enum type_t : uint8_t {
         MustReply = 0x01,
+        ReplySrcPort = 0x02,
         Unicast   = 0x80,
     };
 };

--- a/src/udp_collector.cpp
+++ b/src/udp_collector.cpp
@@ -377,6 +377,13 @@ void UDPCollector::process_one(const uint8_t *buf, size_t nrx, origin_t origin,
         } else {
             replyDest = server;
         }
+        if((origin==Broadcast || origin==Forwarding)
+                && peerVersion >= 3
+                && (flags&pva_search_flags::ReplySrcPort))
+        {
+            // peer requests reply to (apparent) sender port
+            port = origSrc.port();
+        }
         replyDest.setPort(port);
 
         if(!M.good())
@@ -391,8 +398,9 @@ void UDPCollector::process_one(const uint8_t *buf, size_t nrx, origin_t origin,
             *save_flags &= ~pva_search_flags::Unicast;
             // recipient of forwarded message must use, and trust, replyAddr in body :(
             {
-                FixedBuf R(M.be, save_replyAddr, 16u);
+                FixedBuf R(M.be, save_replyAddr, 16u + 2u);
                 to_wire(R, replyDest);
+                to_wire(R, port);
                 assert(R.good());
             }
             forwardM(buf, nrx);


### PR DESCRIPTION
Change the CMD_SEARCH message, adding a reply-to-sender-port flag (`ReplyPort`) to allow for replies to traverse a NAT.

The meaning of that flag is that the recipient should ignore the replyPort field, and instead send a reply to the apparent port which sent the request.

A forwarder should overwrite the replyPort field, ~~and clear this new `ReplyPort` flag~~.

This behavior is enabled by PVA protocol header version `3`.

Potential TODO items for the whole change process:

- [ ] Update protocol spec. doc https://github.com/epics-docs/epics-docs/pull/134
  - [ ] Remove pvAccessCPP protocol docs from wiki
- [ ] Update cashark dissector: https://github.com/mdavidsaver/cashark/pull/16
- [ ] Update `core.pva`
- [ ] Update pvAccessCPP, forwarder only
- [ ] ~~Update pvAccessJava, forwarder only~~ Kay thinks not worthwhile