### PR TITLE
Handle ORIGIN_TAG 0.0.0.0

### DIFF
--- a/src/udp_collector.cpp
+++ b/src/udp_collector.cpp
@@ -501,12 +501,17 @@ void UDPCollector::process_one(const uint8_t *buf, size_t nrx, origin_t origin,
             return;
 
         } else if(origin==Forwarded) {
-            auto ifit(ifinfo.byAddr.find(originaddr));
-            if(ifit!=ifinfo.byAddr.end()) {
-                // original destination is local interface address
+            auto isany = originaddr.isAny(); // valid ORIGIN_TAG, but no additional information
+            decltype(ifinfo.byAddr)::const_iterator ifit;
+            if(!isany)
+                ifit = ifinfo.byAddr.find(originaddr);
+
+            if(isany || ifit!=ifinfo.byAddr.end()) {
+                // original destination is wildcard, or local interface address
                 originaddr.setPort(bind_addr.port());
                 dest = originaddr;
-                srcIface = ifit->second.first;
+                if(!isany)
+                    srcIface = ifit->second.first;
                 process_one(M.save(), M.size(), OriginTag, ifinfo);
                 return;
 


### PR DESCRIPTION
`ORIGIN_TAG` with `0.0.0.0` is documented as valid.  Since it provides no additional information handle as if no tag provided.

Updates 190eb8750f0d31422e621bb95df7b32a0c3ab906

@kasemir reports here https://github.com/epics-docs/epics-docs/pull/134#issuecomment-2977718604