### PR TITLE
a try to compile pvxs correct without  CONFIG_PVXS_MODULE was not loa…

### DIFF
--- a/configure/CONFIG
+++ b/configure/CONFIG
@@ -28,3 +28,6 @@ ifdef T_A
  -include $(TOP)/configure/O.$(T_A)/TOOLCHAIN
 endif
 
+-include $(INSTALL_LOCATION)/cfg/CONFIG_PVXS_MODULE
+-include $(INSTALL_LOCATION)/cfg/CONFIG_PVXS_VERSION
+


### PR DESCRIPTION
Hi @mdavidsaver,

Somehow, still the following errors are shown during the standard compilation with and without `INSTALL_LOCATION`.

Please check this quick-and-dirty workaround, and let me know what you think.

```
$ echo "EPICS_BASE=${HOME}/epics/base" > configure/RELEASE.local
$ make
  make[1]: Entering directory '/home/jeonglee/gitsrc/pvxs/src'
Makefile:31: *** PVXS_MAJOR_VERSION undefined, problem reading cfg/CONFIG_PVXS_VERSION.  Stop.
make[1]: Leaving directory '/home/jeonglee/gitsrc/pvxs/src'
make: *** [/home/jeonglee/epics/1.1.1/debian-12/7.0.7/base/configure/RULES_DIRS:85: src.install] Error 2
```

From the fresh `make`, `configure` and `setup` works fine, However, after that, `configure` make rule returns

```
make -C ./configure install
make[1]: Entering directory '/home/jeonglee/gitsrc/pvxs/configure'
make -C O.linux-x86_64 -f ../Makefile TOP=../.. \
    T_A=linux-x86_64 install
make[2]: Entering directory '/home/jeonglee/gitsrc/pvxs/configure/O.linux-x86_64'
/home/jeonglee/pvxs-test/cfg/RULES_PVXS_MODULE:9: *** CONFIG_PVXS_MODULE was not loaded.  Stop.
make[2]: Leaving directory '/home/jeonglee/gitsrc/pvxs/configure/O.linux-x86_64'
make[1]: *** [/home/jeonglee/epics/1.1.1/debian-12/7.0.7/base/configure/RULES_ARCHS:58: install.linux-x86_64] Error 2
make[1]: Leaving directory '/home/jeonglee/gitsrc/pvxs/configure'
make: *** [/home/jeonglee/epics/1.1.1/debian-12/7.0.7/base/configure/RULES_DIRS:85: configure.install] Error 2
```

Thanks

@jeonghanlee
