### PR TITLE
Bugfix: Answering UDP broadcast requests was broken.

### DIFF
--- a/src/udp_collector.cpp
+++ b/src/udp_collector.cpp
@@ -290,6 +290,7 @@ bool UDPCollector::handle_one(const IfaceMap::Current& ifinfo)
         if(ifit!=srcIface->bcast.end()) {
             // dest is bcast, so replace with associated iface address
             dest = ifit->second;
+            origin = Forwarding;
 
         } else if((ifit=srcIface->addrs.find(dest))!=srcIface->addrs.end()) {
             // dest is interface address.  Nothing to do.


### PR DESCRIPTION
The previous set of patches to fix the wrong source-IP in UDP reply packages did break the mechanism that replies to UDP broadcasts. This is fixed here.