### PR TITLE
fix INSTALL_LOCATION!=TOP

### DIFF
--- a/configure/Makefile
+++ b/configure/Makefile
@@ -13,7 +13,7 @@ include $(TOP)/configure/CONFIG
 #   leave unset to use implicit system search path
 # NOTE: only needed if not present in default search paths
 LIBEVENT ?= $(LIBEVENT_$(T_A))
-LIBEVENT_$(T_A) ?= $(wildcard $(abspath $(TOP)/bundle/usr/$(T_A)))
+LIBEVENT_$(T_A) ?= $(wildcard $(abspath $(INSTALL_LOCATION)/bundle/usr/$(T_A)))
 
 INCLUDES += $(if $(LIBEVENT),-I$(LIBEVENT)/include)
 

--- a/setup/Makefile
+++ b/setup/Makefile
@@ -9,7 +9,7 @@ _PVXS_BOOTSTRAP = YES
 include $(TOP)/configure/CONFIG
 
 LIBEVENT ?= $(LIBEVENT_$(T_A))
-LIBEVENT_$(T_A) ?= $(wildcard $(abspath $(TOP)/bundle/usr/$(T_A)))
+LIBEVENT_$(T_A) ?= $(wildcard $(abspath $(INSTALL_LOCATION)/bundle/usr/$(T_A)))
 
 _LIBEVENT_BUNDLE_LIBS += event_core
 

--- a/setup/RULES_PVXS_MODULE
+++ b/setup/RULES_PVXS_MODULE
@@ -3,6 +3,7 @@
 
 # we're appending so must be idempotent
 ifeq (,$(_PVXS_RULE_INCLUDED))
+ifdef T_A
 _PVXS_RULE_INCLUDED := YES
 
 ifneq ($(_PVXS_CONF_INCLUDED),YES)
@@ -34,4 +35,5 @@ endif
 
 $(foreach loc,$(_PVXS_CHECK_VARS),$(eval $(call _PVXS_ADD_LIBEVENT,$(loc))))
 
+endif # T_A
 endif # _PVXS_RULE_INCLUDED

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,10 +27,6 @@ endif
 # breaks on older ncurses (circa RHEL6) not using the INPUT() trick to pull in libtinfo.so
 #USR_LDFLAGS_Linux += -Wl,--no-undefined -Wl,--no-allow-shlib-undefined
 
-ifeq (,$(PVXS_MAJOR_VERSION))
-$(error PVXS_MAJOR_VERSION undefined, problem reading cfg/CONFIG_PVXS_VERSION)
-endif
-
 # see below for special case versionNum.h
 EXPAND += describe.h
 


### PR DESCRIPTION
Attempts to get `make INSTALL_LOCATION=/some/other/dir` to work correctly.  Including `bundle/`.

Contains the equivalent of #110 after b0b8d60656e98fe0ec62aa91e71c067efc0dd6e2.  It think it also moots #124 by avoiding the `$(error` assertions in TOP, `configure/`, and `setup/` when the contents of `$(INSTALL_LOCATION)/cfg/` are in flux.

@simon-ess @dirk-zimoch @jeonghanlee fyi.