### PR TITLE
ioc: fix timestamp masking for monitor subscriptions

### DIFF
--- a/ioc/singlesource.cpp
+++ b/ioc/singlesource.cpp
@@ -55,8 +55,7 @@ void subscriptionCallback(SingleSourceSubscriptionCtx* subscriptionContext,
 
         {
             DBLocker F(dbChannelRecord(subscriptionContext->info->chan));
-            // TODO MappingInfo::nsecMask
-            IOCSource::get(currentValue, MappingInfo(), Value(), change, pChannel, pDbFieldLog);
+            IOCSource::get(currentValue, *subscriptionContext->info, Value(), change, pChannel, pDbFieldLog);
         }
 
         // Make sure that the initial subscription update has occurred on both channels before continuing

--- a/test/testqsingle.cpp
+++ b/test/testqsingle.cpp
@@ -950,6 +950,27 @@ void testMonitorDBE(TestClient& ctxt)
     testEq(val["value"].as<int32_t>(), 43);
 }
 
+void testMonitorNsecMask(TestClient& ctxt)
+{
+    testDiag("%s", __func__);
+
+    // Regression test for subscriptionCallback passing MappingInfo() instead of
+    // *subscriptionContext->info, which left nsecMask=0 and skipped timestamp masking.
+    TestSubscription sub(ctxt.monitor("test:nsec")
+                         .maskConnected(true)
+                         .maskDisconnected(true));
+
+    auto val(sub.waitForUpdate());
+
+    // nsec:lsb:8 clears the low 8 bits: 102030 -> 101888, userTag -> 142
+    testFldEq(val, "timeStamp.nanoseconds", int32_t(101888));
+#if DBR_UTAG
+    testFldEq(val, "timeStamp.userTag", int32_t(142));
+#else
+    testSkip(1, "no UTAG");
+#endif
+}
+
 void testiocsh(TestClient& ctxt)
 {
     testDiag("%s", __func__);
@@ -1002,7 +1023,7 @@ void testiocsh(TestClient& ctxt)
 
 MAIN(testqsingle)
 {
-    testPlan(113);
+    testPlan(115);
     testSetup();
     pvxs::logger_config_env();
     generalTimeRegisterCurrentProvider("test", 1, &testTimeCurrent);
@@ -1047,6 +1068,7 @@ MAIN(testqsingle)
             testMonitorAIFilt(mctxt);
             testMonitorDBEAlarm(mctxt);
             testMonitorDBE(mctxt);
+            testMonitorNsecMask(mctxt);
             testiocsh(mctxt);
         }
         timeSim = false;


### PR DESCRIPTION
We don't use the `MappingInfo.nsecMask` at ISIS, and don't currently have any plans to do so.  As such, I may have misunderstood the reason for the difference between get and monitor behaviour.

In `subscriptionCallback` in `singlesource.cpp` a default-constructed `MappingInfo()` is passed to `IOCSource::get()`, leaving `nsecMask=0`.  Records with `info(Q:time:tag, "nsec:lsb:N")` had their nanoseconds field unmasked and userTag set incorrectly on monitor updates, while GET returned the right values (with lower bits masked).

This is a one line proposed fix and a regression test for the fix.