### PR TITLE
Fix client self cancel

### DIFF
--- a/ioc/pvalink_channel.cpp
+++ b/ioc/pvalink_channel.cpp
@@ -267,6 +267,7 @@ void pvaLinkChannel::put(bool force)
         // start net Put, cancels in-progress put
         op_put = linkGlobal->provider_remote.put(key.first)
                 .rawRequest(pvReq)
+                .syncCancel(false)
                 .build([this](Value&& prototype) -> Value
         {
                 return linkBuildPut(this, std::move(prototype)); // TODO

--- a/src/clientdiscover.cpp
+++ b/src/clientdiscover.cpp
@@ -93,6 +93,12 @@ std::shared_ptr<Operation> DiscoverBuilder::exec()
         // (maybe) user thread
         auto loop(op->context->tcp_loop);
         auto temp(std::move(op));
+        if(syncCancel && loop.inLoop())
+            log_err_printf(io,
+                           "syncCancel discover '%s' being destroyed on worker thread.\n"
+                           "Possible self-reference loop.  Setup with .syncCancel(false) if intended.\n",
+                           temp->channelName.c_str());
+
         loop.tryInvoke(syncCancel, std::bind([](std::shared_ptr<Discovery>& op){
                            // on worker
                            op->context->discoverers.erase(op.get());

--- a/src/clientdiscover.cpp
+++ b/src/clientdiscover.cpp
@@ -15,6 +15,27 @@ DEFINE_LOGGER(io, "pvxs.client.io");
 namespace pvxs {
 namespace client {
 
+struct Discovery final : public OperationBase
+{
+    const std::shared_ptr<ContextImpl> context;
+    std::function<void(const Discovered &)> notify;
+    bool notify_busy = false;
+    bool running = false;
+
+    Discovery(const std::shared_ptr<ContextImpl>& context, const std::string& name);
+    ~Discovery();
+
+    virtual bool cancel() override final;
+private:
+    bool _cancel(bool implicit);
+
+    // unused for this special case
+    virtual void _reExecGet(std::function<void (Result &&)> &&resultcb) override final;
+    virtual void _reExecPut(const Value &arg, std::function<void (Result &&)> &&resultcb) override final;
+    virtual void createOp() override final;
+    virtual void disconnected(const std::shared_ptr<OperationBase> &self) override final;
+};
+
 Discovery::Discovery(const std::shared_ptr<ContextImpl> &context, const std::string& name)
     :OperationBase (Operation::Discover, context->tcp_loop, name)
     ,context(context)
@@ -31,7 +52,8 @@ bool Discovery::cancel()
     bool ret;
     loop.call([this, &junk, &ret](){
         ret = _cancel(false);
-        junk = std::move(notify);
+        if(!notify_busy)
+            junk = std::move(notify);
         // leave opByIOID for GC
     });
     return ret;
@@ -106,11 +128,13 @@ void ContextImpl::serverEvent(const Discovered &evt)
 {
     for(auto& pair : discoverers) {
         if(auto dis = pair.second.lock()) {
+            dis->notify_busy = true;
             try {
                 dis->notify(evt);
             } catch(std::exception& e) {
                 log_exc_printf(io, "Unhandled exception during Discovery callback : %s\n", e.what());
             }
+            dis->notify_busy = false;
         }
     }
 }

--- a/src/clientget.cpp
+++ b/src/clientget.cpp
@@ -119,6 +119,9 @@ struct GPROp : public OperationBase
     // For GET, PUT a duplicate of RequestInfo::prototype
     Value arg;
     Result result;
+    bool builder_busy = false;
+    bool done_busy = false;
+    bool onInit_busy = false;
     bool getOput = false;
     bool autoExec = true;
 
@@ -156,6 +159,7 @@ struct GPROp : public OperationBase
     }
 
     void notify() {
+        done_busy = true;
         try {
             if(done)
                 done(std::move(result));
@@ -168,17 +172,23 @@ struct GPROp : public OperationBase
             if(!result.error())
                 result = Result(std::current_exception());
         }
+        done_busy = false;
     }
 
     virtual bool cancel() override final
     {
-        decltype (done) junk;
+        decltype (builder) junkB;
+        decltype (done) junkD;
         decltype (onInit) junkI;
         bool ret = false;
-        (void)loop.tryCall([this, &junk, &junkI, &ret](){
+        (void)loop.tryCall([&, this](){
             ret = _cancel(false);
-            junk = std::move(done);
-            junkI = std::move(onInit);
+            if(!builder_busy)
+                junkB = std::move(builder);
+            if(!done_busy)
+                junkD = std::move(done);
+            if(!onInit_busy)
+                junkI = std::move(onInit);
             // leave opByIOID for GC
         });
         return ret;
@@ -218,10 +228,16 @@ struct GPROp : public OperationBase
             if(self->state!=Idle)
                 return;
 
+            if(self->done_busy)
+                throw std::logic_error("done callback in progress");
+
             if(self->op==RPC) {
                 self->arg = std::move(a);
 
             } else if(put && self->op==Put) {
+                if(self->builder_busy)
+                    throw std::logic_error("builder callback in progress");
+
                 self->builder = [a](Value&&) noexcept -> Value {
                     // caller should be passing a Value of the correct prototype
                     // given through onInit().
@@ -275,6 +291,7 @@ struct GPROp : public OperationBase
         if(state==GPROp::BuildPut) {
             temp = arg.clone();
 
+            builder_busy = true;
             try {
                 temp = builder(std::move(temp));
                 state = GPROp::Exec;
@@ -283,6 +300,7 @@ struct GPROp : public OperationBase
                 result = Result(std::current_exception());
                 state = GPROp::Done;
             }
+            builder_busy = false;
         }
 
         // act on new operation state
@@ -517,10 +535,13 @@ void Connection::handle_GPR(pva_app_msg_t cmd)
         if(cmd==CMD_PUT || cmd==CMD_GET)
             gpr->arg = data; // save for later use in sendReply() when RequestInfo not available
 
+        gpr->onInit_busy = true;
         try {
             if(gpr->onInit)
                 gpr->onInit(data);
+            gpr->onInit_busy = false;
         } catch(std::exception& e) {
+            gpr->onInit_busy = false;
             log_err_printf(setup, "Server %s op%02x \"%s\" onInit() error: %s\n",
                            peerName.c_str(), cmd, gpr->chan->name.c_str(), e.what());
             gpr->result = Result(std::current_exception());

--- a/src/clientget.cpp
+++ b/src/clientget.cpp
@@ -613,6 +613,12 @@ std::shared_ptr<Operation> gpr_setup(const std::shared_ptr<ContextImpl>& context
         // (maybe) user thread
         auto temp(std::move(internal));
         auto loop(temp->loop);
+        if(syncCancel && loop.inLoop())
+            log_err_printf(io,
+                           "syncCancel op%u '%s' being destroyed on worker thread.\n"
+                           "Possible self-reference loop.  Setup with .syncCancel(false) if intended.\n",
+                           temp->op, temp->channelName.c_str());
+
         // std::bind for lack of c++14 generalized capture
         // to move internal ref to worker for dtor
         loop.tryInvoke(syncCancel, std::bind([](std::shared_ptr<GPROp>& op) {

--- a/src/clientimpl.h
+++ b/src/clientimpl.h
@@ -25,6 +25,7 @@ namespace client {
 
 struct Channel;
 struct ContextImpl;
+struct Discovery;
 
 struct ResultWaiter {
     epicsMutex lock;
@@ -226,26 +227,6 @@ struct Channel {
     std::shared_ptr<Channel> build(const std::shared_ptr<ContextImpl>& context,
                                    const std::string& name,
                                    const std::string& server);
-};
-
-struct Discovery final : public OperationBase
-{
-    const std::shared_ptr<ContextImpl> context;
-    std::function<void(const Discovered &)> notify;
-    bool running = false;
-
-    Discovery(const std::shared_ptr<ContextImpl>& context, const std::string& name);
-    ~Discovery();
-
-    virtual bool cancel() override final;
-private:
-    bool _cancel(bool implicit);
-
-    // unused for this special case
-    virtual void _reExecGet(std::function<void (Result &&)> &&resultcb) override final;
-    virtual void _reExecPut(const Value &arg, std::function<void (Result &&)> &&resultcb) override final;
-    virtual void createOp() override final;
-    virtual void disconnected(const std::shared_ptr<OperationBase> &self) override final;
 };
 
 struct ContextImpl : public std::enable_shared_from_this<ContextImpl>

--- a/src/clientintrospect.cpp
+++ b/src/clientintrospect.cpp
@@ -207,6 +207,12 @@ std::shared_ptr<Operation> GetBuilder::_exec_info()
         // from user thread
         auto temp(std::move(op));
         auto loop(temp->loop);
+        if(syncCancel && loop.inLoop())
+            log_err_printf(io,
+                           "syncCancel info '%s' being destroyed on worker thread.\n"
+                           "Possible self-reference loop.  Setup with .syncCancel(false) if intended.\n",
+                           temp->channelName.c_str());
+
         // std::bind for lack of c++14 generalized capture
         // to move internal ref to worker for dtor
         loop.tryInvoke(syncCancel, std::bind([](std::shared_ptr<InfoOp>& op) {

--- a/src/clientintrospect.cpp
+++ b/src/clientintrospect.cpp
@@ -21,6 +21,7 @@ struct InfoOp : public OperationBase
 {
     std::function<void(Result&&)> done;
     Value result;
+    bool done_busy = false;
 
     enum state_t {
         Connecting, // waiting for an active Channel
@@ -45,7 +46,8 @@ struct InfoOp : public OperationBase
         bool ret = false;
         (void)loop.tryCall([this, &junk, &ret](){
             ret = _cancel(false);
-            junk = std::move(done);
+            if(!done_busy)
+                junk = std::move(done);
             // leave opByIOID for GC
         });
         return ret;
@@ -160,18 +162,19 @@ void Connection::handle_GET_FIELD()
     info->state = InfoOp::Done;
 
     if(info->done) {
-        auto done = std::move(info->done);
         Result res;
         if(sts.isSuccess()) {
             res = Result(std::move(prototype), peerName);
         } else {
             res = Result(std::make_exception_ptr(RemoteError(sts.msg)));
         }
+        info->done_busy = true;
         try {
-            done(std::move(res));
+            info->done(std::move(res));
         }catch(std::exception& e){
             log_exc_printf(setup, "Unhandled exception %s in Info result() callback: %s\n", typeid (e).name(), e.what());
         }
+        info->done_busy = false;
 
     } else {
         info->result = prototype;

--- a/src/clientmon.cpp
+++ b/src/clientmon.cpp
@@ -830,6 +830,12 @@ std::shared_ptr<Subscription> MonitorBuilder::exec()
         // from user thread
         auto temp(std::move(op));
         auto loop(temp->loop);
+        if(syncCancel && loop.inLoop())
+            log_err_printf(io,
+                           "syncCancel monitor '%s' being destroyed on worker thread.\n"
+                           "Possible self-reference loop.  Setup with .syncCancel(false) if intended.\n",
+                           temp->channelName.c_str());
+
         // std::bind for lack of c++14 generalized capture
         // to move internal ref to worker for dtor
         loop.tryInvoke(syncCancel, std::bind([](std::shared_ptr<SubscriptionImpl>& op) {

--- a/src/clientmon.cpp
+++ b/src/clientmon.cpp
@@ -46,6 +46,8 @@ struct SubscriptionImpl final : public OperationBase, public Subscription
     std::function<void (Subscription&, const Value&)> onInit;
     std::function<void(Subscription&)> event;
     Value pvRequest;
+    bool event_busy = false;
+    bool onInit_busy = false;
     bool pipeline = false;
     bool autostart = true;
     bool maskConn = false, maskDiscon = true;
@@ -109,12 +111,14 @@ struct SubscriptionImpl final : public OperationBase, public Subscription
     void doNotify()
     {
         if(event) {
+            event_busy = true;
             try {
                 event(*this);
             }catch(std::exception& e){
                 log_exc_printf(io, "Unhandled user exception in Monitor %s %s : %s\n",
                                 __func__, typeid (e).name(), e.what());
             }
+            event_busy = false;
         }
     }
 
@@ -276,6 +280,8 @@ struct SubscriptionImpl final : public OperationBase, public Subscription
     virtual void _onEvent(std::function<void(Subscription&)>&& fn) override final {
         decltype (event) junk;
         loop.call([this, &junk, &fn]() {
+            if(event_busy)
+                throw std::logic_error("Must not replace Subscription::onEvent() while callback in progress");
             junk = std::move(event);
             this->event = std::move(fn);
         });
@@ -283,10 +289,14 @@ struct SubscriptionImpl final : public OperationBase, public Subscription
 
     virtual bool cancel() override final {
         decltype (event) junk;
+        decltype (onInit) junkI;
         bool ret = false;
-        (void)loop.tryCall([this, &junk, &ret](){
+        (void)loop.tryCall([this, &junk, &junkI, &ret](){
             ret = _cancel(false);
-            junk = std::move(event);
+            if(!event_busy)
+                junk = std::move(event); // trash when cancelled from app. worker
+            if(!onInit_busy)
+                junkI = std::move(onInit);
             // leave opByIOID for GC
         });
         return ret;
@@ -297,10 +307,12 @@ struct SubscriptionImpl final : public OperationBase, public Subscription
             log_info_printf(io, "Server %s channel %s monitor implied cancel\n",
                             chan->conn ? chan->conn->peerName.c_str() : "<disconnected>",
                             chan->name.c_str());
+
+        } else {
+            log_info_printf(io, "Server %s channel %s monitor cancel\n",
+                            chan->conn ? chan->conn->peerName.c_str() : "<disconnected>",
+                            chan->name.c_str());
         }
-        log_info_printf(io, "Server %s channel %s monitor cancel\n",
-                        chan->conn ? chan->conn->peerName.c_str() : "<disconnected>",
-                        chan->name.c_str());
 
         if(state==Idle || state==Running) {
             chan->conn->sendDestroyRequest(chan->sid, ioid);
@@ -624,6 +636,7 @@ void Connection::handle_MONITOR()
 
         mon->state = SubscriptionImpl::Idle;
 
+        mon->onInit_busy = true;
         try {
             if(mon->onInit)
                 mon->onInit(*mon, info->prototype);
@@ -634,6 +647,7 @@ void Connection::handle_MONITOR()
                             peerName.c_str(),
                             mon->chan->name.c_str(), e.what());
         }
+        mon->onInit_busy = false;
 
         if(mon->autostart && mon->state == SubscriptionImpl::Idle)
             mon->resume();

--- a/src/evhelper.cpp
+++ b/src/evhelper.cpp
@@ -348,6 +348,11 @@ bool evbase::_call(mfunction&& fn, bool dothrow) const
     return true;
 }
 
+bool evbase::inLoop() const
+{
+    return pvt->worker.isCurrentThread();
+}
+
 void evbase::assertInLoop() const
 {
     if(!pvt->worker.isCurrentThread()) {

--- a/src/evhelper.h
+++ b/src/evhelper.h
@@ -198,6 +198,7 @@ public:
             return tryDispatch(std::move(fn));
     }
 
+    bool inLoop() const;
     void assertInLoop() const;
     //! Caller must be on the worker, or the worker must be stopped.
     //! @returns true if working is running.

--- a/test/testmon.cpp
+++ b/test/testmon.cpp
@@ -128,6 +128,39 @@ struct BasicTest {
         testOk1(!done->wait(1.1));
     }
 
+    void cancelDuringEvent()
+    {
+        testShow()<<__func__;
+
+        mbox.open(initial);
+        serv.start();
+
+        // A heap-allocated captured value the callback reads AFTER cancelling.
+        // If the functor (and this capture) were freed by the in-call cancel,
+        // touching `canary` would be a use-after-free (caught under ASan).
+        auto canary(std::make_shared<std::string>("alive"));
+        auto fired(std::make_shared<epicsEvent>());
+        auto ok(std::make_shared<std::atomic<bool>>(false));
+
+        std::shared_ptr<client::Subscription> self;
+        self = cli.monitor("mailbox")
+                   .maskConnected(true)
+                   .maskDisconnected(true)
+                   .event([canary, fired, ok](client::Subscription& s) {
+                       // Re-entrant cancel on this same loop: move-destroys `event`.
+                       s.cancel();
+                       // Touch the capture after the cancel; must still be valid.
+                       ok->store(*canary == "alive");
+                       fired->signal();
+                   })
+                   .exec();
+
+        post(1);
+
+        testOk1(fired->wait(5.0));
+        testOk1(ok->load());
+    }
+
     void badRequest()
     {
         testShow()<<__func__;
@@ -381,13 +414,14 @@ struct TestReconn : public BasicTest
 
 MAIN(testmon)
 {
-    testPlan(43);
+    testPlan(45);
     testSetup();
     try{
         logger_config_env();
         BasicTest().orphan();
         BasicTest().cancel();
         BasicTest().asyncCancel();
+        BasicTest().cancelDuringEvent();
         BasicTest().badRequest();
         BasicTest().testNoMark();
         TestLifeCycle().testBasic(true);


### PR DESCRIPTION
Attempt to resolve #192 .  Alternative to https://github.com/slac-epics/pvxs-tls/pull/18 , including a modified version of that added test case.

@george-mcintyre Please have a look.

The basic goal is to prevent Operation/Subscription callback functors from being free'd while executing.  There are two situations where this may happen.  With API calls which allow a new functor to be set, and as part of cancellation.  This PR changes such that:

- Attempting to assign a new functor during callback execution becomes a `logic_error`.
- Attempting to `cancel()` during callback execution will silent skip freeing the functor.  This being deferred to a later repeated `cancel()`, or destruction.
- Log an ERR if Operation/Subscription destruction happens on the client worker thread and `syncCancel==true` (the default).

With this new ERR condition.  Such situations with `syncCancel==true` are assumed to be accidental, where the caller is not aware of the possibility of a self-reference loop.  eg. The Operation owns the callback which owns the Operation which ...  This is not always true though.  As was the case in QSRV changed by this PR.  However, I think that all such situations should anyway set `syncCancel==false`.

Mechanically, "busy" flags are added for all callback functors.  This includes in the `Discovery` class, which is also moved to be local to `discovery.cpp`.

Functor lifetime during the `handle_*()` methods is tied to a shared_ptr, which remains in-scope until the end of the method.  So, with the added "busy" flags repected, the functor can not be destructed during execution.