### PR TITLE
server: follow TCP port fallback on all interfaces

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -416,7 +416,12 @@ void _fromDefs(Config& self, const std::map<std::string, std::string>& defs, boo
     }
 
     if(pickone({"EPICS_PVAS_INTF_ADDR_LIST"})) {
-        split_addr_into(pickone.name.c_str(), self.interfaces, pickone.val, self.tcp_port, true);
+        // defaultPort=0, matching the client EPICS_PVA_INTF_ADDR_LIST path below.
+        // A port-less interface stays at port 0 so the acceptor loop can follow the
+        // server onto the port actually bound -- including a conflict fallback chosen
+        // while binding the first interface.  Filling in tcp_port here erases that
+        // "follow me" signal and strands the interface on the unbindable port.
+        split_addr_into(pickone.name.c_str(), self.interfaces, pickone.val, 0, true);
     }
 
     if(pickone({"EPICS_PVAS_IGNORE_ADDR_LIST"})) {

--- a/test/testconfig.cpp
+++ b/test/testconfig.cpp
@@ -141,7 +141,9 @@ void testDefs()
         testEq(conf.tcp_port, 5678);
         testFalse(conf.auto_beacon);
         testEq(conf.beaconDestinations, std::vector<std::string>({"1.2.1.2:1234", "4.3.2.1:1234"}));
-        testEq(conf.interfaces, std::vector<std::string>({"1.1.1.1:5678", "1.2.3.4:5678"}));
+        // server INTF list round-trips port-less, matching the client path above
+        // (a port-less interface follows the server's bound TCP port at bind time).
+        testEq(conf.interfaces, std::vector<std::string>({"1.1.1.1", "1.2.3.4"}));
     }
 }
 

--- a/test/testwild.cpp
+++ b/test/testwild.cpp
@@ -80,11 +80,39 @@ void testconflict(const char* addr)
     testNotEq(iconf.tcp_port, fconf.tcp_port)<<"w/ "<<addr;
 }
 
+// as testconflict(), but configured as a user would.
+// $EPICS_PVAS_INTF_ADDR_LIST fills in $EPICS_PVAS_SERVER_PORT for each interface
+// which does not name a port, so the interfaces arrive here carrying the port
+// which is about to be found in use.  All of them must still follow the fallback.
+void testconflictifaces(const char* addr1, const char* addr2)
+{
+    testDiag("%s(\"%s\", \"%s\")", __func__, addr1, addr2);
+
+    evsocket otherserver(AF_INET, SOCK_STREAM, 0);
+    otherserver.bind(SockAddr::any(AF_INET));
+    otherserver.listen(4);
+
+    server::Config::defs_t defs;
+    defs["EPICS_PVAS_SERVER_PORT"] = SB()<<otherserver.sockname().port();
+    defs["EPICS_PVAS_BROADCAST_PORT"] = "0"; // choose randomly
+    defs["EPICS_PVAS_INTF_ADDR_LIST"] = SB()<<addr1<<' '<<addr2;
+
+    server::Config iconf;
+    iconf.applyDefs(defs);
+
+    auto serv(iconf.build());
+    auto fconf(serv.config());
+    testShow()<<"Server Config\n"<<fconf;
+
+    testNotEq(0u, fconf.udp_port);
+    testNotEq(iconf.tcp_port, fconf.tcp_port);
+}
+
 } // namespace
 
 MAIN(testwild)
 {
-    testPlan(18);
+    testPlan(20);
     testSetup();
     logger_config_env();
     SockAttach attach;
@@ -98,8 +126,10 @@ MAIN(testwild)
     }
     if(evsocket::ipstack==evsocket::Linsock) {
         testconflict("127.0.0.1");
+        // 127.0.0.0/8 is entirely local, so a second loopback address is available.
+        testconflictifaces("127.0.0.1", "127.0.0.2");
     } else {
-        testSkip(2, "Can bind both 0.0.0.0 and 127.0.0.1 to the same port");
+        testSkip(4, "Can bind both 0.0.0.0 and 127.0.0.1 to the same port, and have one loopback address");
     }
     testconflict("0.0.0.0");
     if(canIPv6) {


### PR DESCRIPTION
A server binding several interfaces aborts if the configured TCP port is in use. The first interface falls back to a dynamically assigned port, but the rest retry the original port, which is still busy, and are not allowed to fall back in turn. The `Server` ctor then throws, so an IOC loses its PVA server entirely where a single-interface server would have survived.

Reproduce with a second `softIocPVX` started under:

```
EPICS_PVAS_INTF_ADDR_LIST="127.0.0.1 192.168.2.127 100.71.48.68"
EPICS_PVAS_SERVER_PORT=5085
```

The second IOC reports

```
ERR pvxs.tcp.setup Bind to 127.0.0.1:5085 fails after fallback with 98
Error in pvxsBaseRegistrar : Address already in use
```

while `iocInit()` otherwise completes, leaving an IOC with no PVA server at all.

Interfaces which do not name a port already adopt `effective.tcp_port`, which is how a server with `EPICS_PVAS_SERVER_PORT=0` puts all of its interfaces on one dynamically assigned port. This change extends that to the port found in use: an interface asking for the server TCP port follows the server onto the port actually bound.

Note the bug is only reachable through the environment: `split_addr_into()` fills in `$EPICS_PVAS_SERVER_PORT` for entries which omit a port, so by the time the interface loop runs, "use the server's port" is spelled either as port zero or as the configured port itself. Both now follow the fallback. An interface naming some *other* explicit port is a deliberate choice and keeps it.

Includes a regression test (`testconflictifaces` in `testwild.cpp`) using the existing wildcard-bind occupancy pattern; it fails deterministically before the fix and passes after (20/20 both ways). It is gated to the Linux IP stack alongside the adjacent `testconflict` case, as it needs a second loopback address.
