### PR TITLE
ioc: serve display.precision independent of DBR_GR_DOUBLE

### DIFF
--- a/documentation/releasenotes.rst
+++ b/documentation/releasenotes.rst
@@ -11,6 +11,8 @@ Release Notes
   "->booleanValue" may be replaced with "booleanValue".
 - tools: The CLI tools are now built only with epics-base >= 3.15 .
 - tools: pvxput now understand JSON syntax.
+- ioc: serve ``display.precision`` for a field whose rset supplies
+  ``get_precision`` but NULLs ``get_graphic_double`` (Sang Woo Kim)
 
 1.5.2 (Jun 2026)
 ----------------

--- a/ioc/iocsource.cpp
+++ b/ioc/iocsource.cpp
@@ -288,9 +288,14 @@ void getProperties(dbChannel* pChannel, db_field_log *pfl, Value& node)
         if(options & DBR_GR_DOUBLE) {
             dlL = meta.lower_disp_limit;
             node["display.limitHigh"] = meta.upper_disp_limit;
-            if(options & DBR_PRECISION) {
-                node["display.precision"] = int32_t(meta.precision.dp);
-            }
+        }
+        if(options & DBR_PRECISION) {
+            // DBR_PRECISION (get_precision) is an rset slot independent of
+            // DBR_GR_DOUBLE (get_graphic_double).  A field that supplies the
+            // former while NULLing the latter (e.g. bo, mbbiDirect, mbboDirect)
+            // has a precision to serve but no display limits; gate it on its
+            // own slot rather than nesting it under the graphic-limits branch.
+            node["display.precision"] = int32_t(meta.precision.dp);
         }
         if(options & DBR_CTRL_DOUBLE) {
             node["control.limitLow"] = meta.lower_ctrl_limit;

--- a/test/testqsingle.cpp
+++ b/test/testqsingle.cpp
@@ -148,6 +148,30 @@ void testGetScalar()
               "valueAlarm.highAlarmLimit double = 100\n"
             )<<" fetch VAL w/ meta-data.  delta output";
 
+    // A field whose record supplies get_precision but NULLs get_graphic_double
+    // (bo, mbbiDirect, mbboDirect) must still be served its display.precision:
+    // DBR_PRECISION and DBR_GR_DOUBLE are independent rset slots.  bo.HIGH
+    // reports boHIGHprecision (2) while bo NULLs get_graphic_double, so the
+    // delta carries display.precision but neither display.limitLow nor
+    // display.limitHigh.
+    val = ctxt.get("test:precprop.HIGH").exec()->wait(5.0);
+    testStrEq(std::string(SB()<<val.format().delta()),
+              "value double = 5\n"
+              "alarm.severity int32_t = 3\n"
+              "alarm.status int32_t = 2\n"
+              "alarm.message string = \"UDF\"\n"
+              "timeStamp.secondsPastEpoch int64_t = 631152000\n"
+              "timeStamp.nanoseconds int32_t = 0\n"
+              "timeStamp.userTag int32_t = 0\n"
+              "display.description string = \"\"\n"
+              "display.units string = \"s\"\n"
+              "display.precision int32_t = 2\n"
+              "display.form.choices string[] = {7}[\"Default\", \"String\", \"Binary\", \"Decimal\", \"Hex\", \"Exponential\", \"Engineering\"]\n"
+              "control.limitLow double = 0\n"
+              "control.limitHigh double = 100000\n"
+            )<<" precprop.HIGH serves display.precision though bo NULLs "
+              "get_graphic_double; display.limitLow/limitHigh stay absent";
+
     val = ctxt.get("test:ai.DESC").exec()->wait(5.0);
     checkUTAG(val);
     testStrEq(std::string(SB()<<val.format()),

--- a/test/testqsingle.db
+++ b/test/testqsingle.db
@@ -65,3 +65,6 @@ record(longin, "test:nsec") {
     field(VAL , "100")
     info(Q:time:tag, "nsec:lsb:8")
 }
+record(bo, "test:precprop") {
+    field(HIGH, "5")
+}


### PR DESCRIPTION
## Problem

`getProperties()` (`ioc/iocsource.cpp`) nests the `display.precision`
assignment inside the `if(options & DBR_GR_DOUBLE)` branch:

```cpp
if(options & DBR_GR_DOUBLE) {
    dlL = meta.lower_disp_limit;
    node["display.limitHigh"] = meta.upper_disp_limit;
    if(options & DBR_PRECISION) {
        node["display.precision"] = int32_t(meta.precision.dp);
    }
}
```

`DBR_PRECISION` (`get_precision`) and `DBR_GR_DOUBLE` (`get_graphic_double`)
are **independent** rset slots. A field whose record supplies `get_precision`
but NULLs `get_graphic_double` therefore never has its precision served over
PVA — even though CA serves it fine. `display.units`, one block above, is
already gated on its own `DBR_UNITS` slot; `display.precision` was the odd
one out.

In EPICS base, `bo`, `mbbiDirect` and `mbboDirect` are exactly the record
types whose rset supplies `get_precision` while `#define get_graphic_double
NULL`; several modules (`busy`, `asyn`, `transform`, `sseq`) do the same. For
all of them the precision leaf is silently dropped over PVA.

## Fix

Gate `display.precision` on its own `DBR_PRECISION` slot, as a sibling of the
graphic-limits branch rather than nested inside it. One assignment moved up
one brace level.

## Test

Adds a `testqsingle` case using `test:precprop.HIGH` (`bo.HIGH` reports
`boHIGHprecision` = 2, while `bo` NULLs `get_graphic_double`). After the fix
its monitor delta carries `display.precision int32_t = 2` while
`display.limitLow`/`display.limitHigh` stay absent. The case **fails without
this fix** and passes with it. Full `testqsingle` run: 114/114.

## How it was found

Surfaced by a differential-oracle parity check of an independent Rust QSRV2
reimplementation against `softIocPVX` as ground truth: the read/monitor
marking diff resolved to exactly this family — 7 record types, 62 read
channels — every one a `display.precision`-only difference whose served value
matches what CA already reports. Only `bo.HIGH` carries a non-default
precision (2); the rest serve 0 (`recGblGetPrec` default), which is why the
drop had gone unnoticed.