### PR TITLE
rtems: gate the RTEMS 5 workarounds that break RTEMS 6

### DIFF
--- a/bundle/cmake/Platform/RTEMS.cmake
+++ b/bundle/cmake/Platform/RTEMS.cmake
@@ -24,8 +24,16 @@ set(CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
 )
 set(CMAKE_SYSTEM_LIBRARY_PATH ${CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES})
 
+# RTEMS 6 no longer installs a BSP spec file.  Passing -specs bsp_specs to
+# an RTEMS 6 toolchain fails before anything is compiled.
+if(CMAKE_SYSTEM_VERSION VERSION_LESS 6)
+  set(_rtems_bsp_specs "-specs bsp_specs ")
+else()
+  set(_rtems_bsp_specs "")
+endif()
+
 set(CMAKE_C_FLAGS_INIT
- "-B${RTEMS_TARGET_PREFIX}/${RTEMS_BSP}/lib/ -specs bsp_specs -qrtems ${RTEMS_BSP_C_FLAGS}"
+ "-B${RTEMS_TARGET_PREFIX}/${RTEMS_BSP}/lib/ ${_rtems_bsp_specs}-qrtems ${RTEMS_BSP_C_FLAGS}"
 )
 set(CMAKE_C_FLAGS_INIT ${CMAKE_C_FLAGS_INIT})
 

--- a/src/evhelper.cpp
+++ b/src/evhelper.cpp
@@ -11,6 +11,10 @@
 #  include <mswsock.h>
 #endif
 
+#ifdef __rtems__
+#  include <rtems/score/cpuopts.h>
+#endif
+
 #include <cstring>
 #include <system_error>
 #include <deque>
@@ -175,12 +179,20 @@ struct evbase::Pvt final : public epicsThreadRunable
         try {
             evconfig conf(__FILE__, __LINE__, event_config_new());
 #ifdef __rtems__
+#  if (__RTEMS_MAJOR__ < 6) || (__RTEMS_MAJOR__ == 6 && __RTEMS_MINOR__ <= 2)
             /* with libbsd circa RTEMS 5.1
              * TCP peer close/reset notifications appear to be lost.
              * Maybe due to absence of NOTE_EOF?
              * poll() seems to work though.
+             *
+             * The rtems-libbsd descriptor fixes restoring kqueue ship in
+             * RTEMS 6.3; the version condition follows the rtems-libbsd
+             * maintainer's recommendation.  Note the poll backend spins
+             * on RTEMS 6: libbsd reports POLLERR for the pipe() libevent
+             * notifies itself through.
              */
             event_config_avoid_method(conf.get(), "kqueue");
+#  endif
 #endif
             decltype (base) tbase(__FILE__, __LINE__, event_base_new_with_config(conf.get()));
             if(evthread_make_base_notifiable(tbase.get())) {


### PR DESCRIPTION
Both are RTEMS 5-era workarounds that break RTEMS 6 — `-specs bsp_specs` (removed in RTEMS 6) blocks the build, and avoiding kqueue puts libevent on the poll backend where libbsd's POLLERR on its notify pipe spins `event_base_loop()` before `iocInit` — so gate each on `CMAKE_SYSTEM_VERSION` / `__RTEMS_MAJOR__` rather than remove it.