### PR TITLE
python: publish linux-aarch64 wheels on native ARM runners

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -10,7 +10,7 @@ jobs:
   manylinux:
     name: py${{ matrix.py }} ${{ matrix.ml }}
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -51,6 +51,34 @@ jobs:
 
         - ml: manylinux_2_28_x86_64
           py: cp314-cp314t
+
+        - ml: manylinux2014_aarch64
+          py: cp39-cp39
+          runner: ubuntu-24.04-arm
+
+        - ml: manylinux2014_aarch64
+          py: cp310-cp310
+          runner: ubuntu-24.04-arm
+
+        - ml: manylinux2014_aarch64
+          py: cp311-cp311
+          runner: ubuntu-24.04-arm
+
+        - ml: manylinux2014_aarch64
+          py: cp312-cp312
+          runner: ubuntu-24.04-arm
+
+        - ml: manylinux2014_aarch64
+          py: cp313-cp313
+          runner: ubuntu-24.04-arm
+
+        - ml: manylinux_2_28_aarch64
+          py: cp314-cp314
+          runner: ubuntu-24.04-arm
+
+        - ml: manylinux_2_28_aarch64
+          py: cp314-cp314t
+          runner: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## linux-aarch64 wheels for the EPICS PVA stack

There is no `linux-aarch64` wheel on PyPI for `epicscorelibs`, `pvxslibs` or `p4p`, at any interpreter. All three publish `macosx_11_0_universal2`, `manylinux2014_x86_64` / `manylinux_2_28_x86_64` and `win_amd64` only. So on arm64 Linux `pip install p4p` source-builds all three and needs a C toolchain on the host. A container image can stage one; a bare-metal install cannot be assumed to have one.

Three PRs, one per repo, adding the missing rows:

- epics-base/epicscorelibs#56 — `epicscorelibs`
- epics-base/pvxs#201 — `pvxslibs`
- epics-base/p4p#226 — `p4p`

They need to merge in that order: `pvxslibs` builds against `epicscorelibs`, and `p4p` against both. Until the one above it has merged and published, each downstream PR's aarch64 jobs are expected to fail — see the note in each.

**Why now.** epics-base/epicscorelibs#21 and epics-base/pvxs#48 proposed this in 2023 using QEMU, and were closed unmerged in favour of waiting for ARM-based hosted runners. Those runners are now generally available and free on public repositories, which removes both objections raised in that discussion: the build is native rather than ~40 minutes emulated, and the unit tests run against a real kernel, so `qemu-user` not translating `IP_MULTICAST_ALL`, `SO_RXQ_OVFL`, `IP_MULTICAST_IF` and `IPV6_MULTICAST_IF` is no longer a factor.

**The change, identical in all three:**

- `runs-on: ${{ matrix.runner || 'ubuntu-latest' }}`, following the existing `${{ matrix.cy || 'Cython' }}` idiom, so the x86_64 and native rows are untouched.
- New `manylinux2014_aarch64` rows for cp39–cp313 and `manylinux_2_28_aarch64` for cp314/cp314t, mirroring the x86_64 set, each with `runner: ubuntu-24.04-arm`.
- Nothing cross-compiles: `ubuntu-24.04-arm` builds `linux-aarch64` natively. (epics-base/ci-scripts already builds that target, as a cross-compile.)
- `podman` 5.8.4 is preinstalled on `ubuntu-24.04-arm`, the same version as on the x64 image, so the `podman run` step is unchanged.
- `mdavidsaver/ci-core-dumper@master` is a `node24` action and GitHub-provided runtimes are arm64-native, so it needs no change.
- Artifact names already include `matrix.ml`, so nothing collides, and `src: true` stays on the x86_64 cp314 row only.

### This repo

Second in the chain. Continues #48, which was closed unmerged in Oct 2023 in favour of native runners.

**Expect the aarch64 rows to fail on this PR until epics-base/epicscorelibs#56 merges and publishes.** The existing download line already carries `--only-binary epicscorelibs`, so with no aarch64 wheel available `pip download` fails immediately with a resolver error naming it, rather than falling back to the sdist. That is the intended behaviour and it costs almost no runner time. A re-run once epicscorelibs publishes should be clean; every other row is unaffected.
