### PR TITLE
ioc: size a DBR_STRING array read by the request stride, not field_size

### DIFF
--- a/ioc/iocsource.cpp
+++ b/ioc/iocsource.cpp
@@ -121,7 +121,14 @@ void getArrayValue(dbChannel* pChannel,
                          Value& value)
 {
     auto final_type(dbChannelFinalFieldType(pChannel));
-    auto buf(std::make_shared<std::vector<char>>(dbChannelFinalElements(pChannel) * dbChannelFinalFieldSize(pChannel)));
+    // Size the buffer by the request type's output element size, not the
+    // field's storage size: dbGet() writes dbValueSize(final_type) bytes per
+    // element, which is MAX_STRING_SIZE for DBR_STRING regardless of the
+    // field's own size (dbConvert.c getStringString strides pdst by
+    // MAX_STRING_SIZE).  For numeric types dbValueSize() == field_size, so a
+    // type-changing filter (e.g. ts -> DBR_DOUBLE) is unaffected, while a
+    // DBF_STRING field with field_size < MAX_STRING_SIZE can no longer overrun.
+    auto buf(std::make_shared<std::vector<char>>(dbChannelFinalElements(pChannel) * dbValueSize(final_type)));
     long nReq = dbChannelFinalElements(pChannel);
 
     DBErrorMessage dbErrorMessage(dbChannelGet(pChannel, final_type,


### PR DESCRIPTION
getArrayValue sized its buffer from dbChannelFinalFieldSize, but dbGet writes dbValueSize(final_type) bytes per element — MAX_STRING_SIZE for a DBR_STRING request regardless of the field's own size — so a DBF_STRING field with field_size < 40 (synApps scalcout's PAA..PLL) overflowed the heap.

Size by dbValueSize(final_type) instead: unchanged for numeric fields and type-changing filters (where dbValueSize == field_size, e.g. ts -> DBR_DOUBLE), and MAX_STRING_SIZE for strings. This keeps the field_size-based design while making a malformed field_size unable to overrun the buffer.

Fixes #205.